### PR TITLE
feat: users / topics / activities のモックデータを作成する (#3)

### DIFF
--- a/src/mocks/activities.ts
+++ b/src/mocks/activities.ts
@@ -1,0 +1,700 @@
+import { type Activity } from "@/types/activity";
+
+// ─── topic-1-1: 読書（user-1） ─────────────────────────────────
+const topic1_1Activities: Activity[] = [
+  {
+    id: "act-1-1-1",
+    topicId: "topic-1-1",
+    userId: "user-1",
+    body: "『三体』読了。宇宙の広大さにめまいがした。ハードSFはやっぱり面白い。続刊もすぐ読みたい。",
+    createdAt: "2026-01-05T21:15:00+09:00",
+  },
+  {
+    id: "act-1-1-2",
+    topicId: "topic-1-1",
+    userId: "user-1",
+    body: "『坊っちゃん』を再読。子供の頃は主人公に共感しっぱなしだったけど、今読むと周りの大人たちの気持ちもわかって複雑な感情になる。",
+    createdAt: "2026-01-20T22:00:00+09:00",
+  },
+  {
+    id: "act-1-1-3",
+    topicId: "topic-1-1",
+    userId: "user-1",
+    body: "『1984年』を読み始めた。オーウェルが1940年代に書いたとは思えないほど現代社会と符合する部分が多くて、少し怖い。",
+    createdAt: "2026-02-03T20:30:00+09:00",
+  },
+  {
+    id: "act-1-1-4",
+    topicId: "topic-1-1",
+    userId: "user-1",
+    body: "『1984年』読了。ビッグブラザーの圧迫感が頭から離れない。ラストの一文「彼は自分がビッグブラザーを愛していることに気づいた」が重すぎる。",
+    createdAt: "2026-02-18T23:10:00+09:00",
+  },
+  {
+    id: "act-1-1-5",
+    topicId: "topic-1-1",
+    userId: "user-1",
+    body: "図書館で予約していた『夜と霧』がやっと手元に届いた。フランクルの文章は静かで力強い。",
+    createdAt: "2026-03-01T18:45:00+09:00",
+  },
+  {
+    id: "act-1-1-6",
+    topicId: "topic-1-1",
+    userId: "user-1",
+    body: "『夜と霧』読了。生きることの意味について深く考えさせられた。今年読んだ中で間違いなくベスト1。何度でも読み返したい本。",
+    createdAt: "2026-03-15T23:30:00+09:00",
+  },
+  {
+    id: "act-1-1-7",
+    topicId: "topic-1-1",
+    userId: "user-1",
+    body: "村上春樹の新作を購入。週末にじっくり読む予定。装丁が好み。",
+    createdAt: "2026-03-28T19:00:00+09:00",
+  },
+];
+
+// ─── topic-1-2: 映画（user-1） ─────────────────────────────────
+const topic1_2Activities: Activity[] = [
+  {
+    id: "act-1-2-1",
+    topicId: "topic-1-2",
+    userId: "user-1",
+    body: "『オッペンハイマー』IMAXで鑑賞。普通のスクリーンで見ないで正解だった。核爆発のシーンは音響が全然違う。3時間があっという間。",
+    imageUrls: ["https://picsum.photos/seed/oppenheimer/600/400"],
+    createdAt: "2026-01-10T23:00:00+09:00",
+  },
+  {
+    id: "act-1-2-2",
+    topicId: "topic-1-2",
+    userId: "user-1",
+    body: "Amazon Primeで『デューン 砂の惑星 PART 2』を視聴。砂漠のビジュアルとスコアの組み合わせが圧倒的。ヴィルヌーヴ監督はスケール感の演出が段違い。",
+    createdAt: "2026-01-25T22:30:00+09:00",
+  },
+  {
+    id: "act-1-2-3",
+    topicId: "topic-1-2",
+    userId: "user-1",
+    body: "近所のミニシアターで『ドライブ・マイ・カー』の再上映があったので2回目の鑑賞。初見より台詞の一つひとつが刺さった。また泣いた。",
+    createdAt: "2026-02-08T21:45:00+09:00",
+  },
+  {
+    id: "act-1-2-4",
+    topicId: "topic-1-2",
+    userId: "user-1",
+    body: "子供と一緒に『モアナと伝説の海2』。子供が曲を覚えて帰り道ずっと歌ってた。それだけで十分満足。",
+    createdAt: "2026-02-22T18:00:00+09:00",
+  },
+  {
+    id: "act-1-2-5",
+    topicId: "topic-1-2",
+    userId: "user-1",
+    body: "映画館で『哀れなるものたち』。ヨルゴス・ランティモスは毎回なんとも言えない後味を残してくれる。好き嫌いは分かれると思うが、映像の独創性は本物。",
+    createdAt: "2026-03-10T23:15:00+09:00",
+  },
+  {
+    id: "act-1-2-6",
+    topicId: "topic-1-2",
+    userId: "user-1",
+    body: "Netflixで韓国映画を3本。最近こっちにはまり気味かも。特に『パラサイト』以降の韓国映画のレベルの高さを実感している。",
+    createdAt: "2026-03-25T22:00:00+09:00",
+  },
+];
+
+// ─── topic-1-3: 料理日記（user-1） ────────────────────────────
+const topic1_3Activities: Activity[] = [
+  {
+    id: "act-1-3-1",
+    topicId: "topic-1-3",
+    userId: "user-1",
+    body: "チキンカレーを作った。玉ねぎをじっくり炒めるとやっぱり全然違う。1時間かけた甲斐があった。スパイスはクミン・コリアンダー・ターメリック・ガラムマサラの4種。",
+    imageUrls: ["https://picsum.photos/seed/curry/600/400"],
+    createdAt: "2026-01-08T19:30:00+09:00",
+  },
+  {
+    id: "act-1-3-2",
+    topicId: "topic-1-3",
+    userId: "user-1",
+    body: "餃子パーティ。今回は肉汁多め意識で、白菜を塩もみして水分をしっかり絞った。皮は市販品だけど、焼き加減を少し丁寧にしたらパリパリに仕上がって正解だった。",
+    imageUrls: ["https://picsum.photos/seed/gyoza/600/400"],
+    createdAt: "2026-01-22T20:00:00+09:00",
+  },
+  {
+    id: "act-1-3-3",
+    topicId: "topic-1-3",
+    userId: "user-1",
+    body: "ミネストローネ。冷蔵庫の野菜を一掃できてよかった。パスタを入れると昼ごはんにもなるし、スープとして出せるしで用途が広い。",
+    createdAt: "2026-02-05T19:00:00+09:00",
+  },
+  {
+    id: "act-1-3-4",
+    topicId: "topic-1-3",
+    userId: "user-1",
+    body: "バレンタイン後のセールでカカオ70%チョコが半額になっていたのでガトーショコラを焼いた。しっとり系に仕上がって好評だった。",
+    imageUrls: ["https://picsum.photos/seed/gateau/600/400"],
+    createdAt: "2026-02-20T21:00:00+09:00",
+  },
+  {
+    id: "act-1-3-5",
+    topicId: "topic-1-3",
+    userId: "user-1",
+    body: "鮭のちゃんちゃん焼きに初挑戦。ホットプレートで作ると卓上調理になって楽しい。味噌・バター・砂糖のたれが最高だった。",
+    createdAt: "2026-03-05T20:30:00+09:00",
+  },
+  {
+    id: "act-1-3-6",
+    topicId: "topic-1-3",
+    userId: "user-1",
+    body: "春キャベツが出てきたので回鍋肉。甜麺醤をたっぷり使うと本格的な味になる。春キャベツの甘みが際立って普通のキャベツより美味しい気がする。",
+    createdAt: "2026-03-18T19:45:00+09:00",
+  },
+  {
+    id: "act-1-3-7",
+    topicId: "topic-1-3",
+    userId: "user-1",
+    body: "桜餅を作ってみた。道明寺粉が近所のスーパーで手に入って嬉しかった。桜の葉の塩漬けはネットで購入。見た目もかわいく仕上がった。",
+    imageUrls: ["https://picsum.photos/seed/sakuramochi/600/400"],
+    createdAt: "2026-03-30T17:00:00+09:00",
+  },
+];
+
+// ─── topic-1-4: 今日の出来事（user-1） ───────────────────────
+const topic1_4Activities: Activity[] = [
+  {
+    id: "act-1-4-1",
+    topicId: "topic-1-4",
+    userId: "user-1",
+    body: "朝から大雪で急遽フル在宅勤務に切り替え。コーヒーを淹れながらのんびり仕事。外が白くなっていると不思議と集中できる。悪くない一日だった。",
+    createdAt: "2026-01-15T22:00:00+09:00",
+  },
+  {
+    id: "act-1-4-2",
+    topicId: "topic-1-4",
+    userId: "user-1",
+    body: "友人とボードゲームカフェへ。カタン・ドミニオン・アズールを4時間ぶっ通しでプレイ。頭がパンパンになったけどとても楽しかった。",
+    createdAt: "2026-01-28T23:30:00+09:00",
+  },
+  {
+    id: "act-1-4-3",
+    topicId: "topic-1-4",
+    userId: "user-1",
+    body: "年一の健康診断。血圧・血糖値は問題なし。ただ体重が昨年比2kg増えていた。春から意識して動かないといけない。",
+    createdAt: "2026-02-10T18:30:00+09:00",
+  },
+  {
+    id: "act-1-4-4",
+    topicId: "topic-1-4",
+    userId: "user-1",
+    body: "転職した友人からLINEで連絡がきてランチへ。環境が変わると本当に人って変わるんだなと実感した。いろんな意味でいい刺激になった。",
+    createdAt: "2026-02-25T14:00:00+09:00",
+  },
+  {
+    id: "act-1-4-5",
+    topicId: "topic-1-4",
+    userId: "user-1",
+    body: "週末の散歩中に近所の公園で梅が満開だった。スマホで写真を大量に撮ったけど実物の香りはやっぱり写真には残せない。",
+    imageUrls: ["https://picsum.photos/seed/plumblossom/600/400"],
+    createdAt: "2026-03-08T16:00:00+09:00",
+  },
+  {
+    id: "act-1-4-6",
+    topicId: "topic-1-4",
+    userId: "user-1",
+    body: "子供の卒業式。あっという間だなあ、という言葉しか出てこなかった。成長を喜びつつ、少し寂しい気持ちも残る。",
+    createdAt: "2026-03-22T20:00:00+09:00",
+  },
+];
+
+// ─── topic-2-1: 読んだ本（user-2） ───────────────────────────
+const topic2_1Activities: Activity[] = [
+  {
+    id: "act-2-1-1",
+    topicId: "topic-2-1",
+    userId: "user-2",
+    body: "『限りある時間の使い方』読了。タスク管理のハウツー本かと思いきや、実はかなり哲学的な内容だった。「4000週間という人生の有限性を直視せよ」というメッセージが刺さった。",
+    createdAt: "2026-01-06T21:30:00+09:00",
+  },
+  {
+    id: "act-2-1-2",
+    topicId: "topic-2-1",
+    userId: "user-2",
+    body: "村田沙耶香『コンビニ人間』を読んだ。短いのにすごく密度が高い。主人公の「普通」への違和感の描き方が秀逸で、読み終えてもしばらく考えさせられた。",
+    createdAt: "2026-01-19T23:00:00+09:00",
+  },
+  {
+    id: "act-2-1-3",
+    topicId: "topic-2-1",
+    userId: "user-2",
+    body: "川上未映子『黄色い家』を読んだ。500ページ以上あるのに全然飽きなかった。貧困と連帯と裏切りの話で、読んでいる間ずっと胸が痛かった。",
+    createdAt: "2026-02-02T23:30:00+09:00",
+  },
+  {
+    id: "act-2-1-4",
+    topicId: "topic-2-1",
+    userId: "user-2",
+    body: "ついに『ハリー・ポッター』全7巻を読み終えた！今更感はあるけれど、ちゃんと感動した。ハーマイオニーが最初から最後まで好き。",
+    createdAt: "2026-02-16T22:00:00+09:00",
+  },
+  {
+    id: "act-2-1-5",
+    topicId: "topic-2-1",
+    userId: "user-2",
+    body: "積読消化週間中。穂村弘の歌集を手にとった。短歌の世界に初めてちゃんと入り込めた気がする。「短歌って面白い」を実感した今週。",
+    createdAt: "2026-03-03T21:00:00+09:00",
+  },
+  {
+    id: "act-2-1-6",
+    topicId: "topic-2-1",
+    userId: "user-2",
+    body: "最近は電子書籍と紙を使い分けてる。電子は移動中に便利、紙は漫画や写真集。紙の漫画を久しぶりに読んだら読み心地の違いを再確認した。",
+    createdAt: "2026-03-20T21:30:00+09:00",
+  },
+];
+
+// ─── topic-2-2: カフェ巡り（user-2） ─────────────────────────
+const topic2_2Activities: Activity[] = [
+  {
+    id: "act-2-2-1",
+    topicId: "topic-2-2",
+    userId: "user-2",
+    body: "表参道の隠れ家カフェへ。豆の産地にこだわりがあって、今日はエチオピア産の浅煎りをチョイス。フルーティーな酸味が絶品で、コーヒーの概念が変わりそうだった。",
+    imageUrls: ["https://picsum.photos/seed/omotesando-cafe/600/400"],
+    createdAt: "2026-01-11T15:00:00+09:00",
+  },
+  {
+    id: "act-2-2-2",
+    topicId: "topic-2-2",
+    userId: "user-2",
+    body: "代官山のドッグカフェへ。友達の柴犬を連れて行ったら他のお客さんにもすごく人気で大変なことに。ラテアートのテラスが気持ちよかった。",
+    imageUrls: ["https://picsum.photos/seed/dogcafe/600/400"],
+    createdAt: "2026-01-24T14:30:00+09:00",
+  },
+  {
+    id: "act-2-2-3",
+    topicId: "topic-2-2",
+    userId: "user-2",
+    body: "新宿の老舗喫茶店でナポリタン。昭和の内装と木のカウンター、鉄板の香り。「喫茶店のナポリタン」という文化を守り続けてほしい。",
+    imageUrls: ["https://picsum.photos/seed/napolitano/600/400"],
+    createdAt: "2026-02-07T12:30:00+09:00",
+  },
+  {
+    id: "act-2-2-4",
+    topicId: "topic-2-2",
+    userId: "user-2",
+    body: "吉祥寺を散歩しながらカフェを3件はしご。カプチーノ×3杯飲んでカフェイン過多になった笑。でも雰囲気の違うお店を巡るのは楽しい。",
+    createdAt: "2026-02-21T17:00:00+09:00",
+  },
+  {
+    id: "act-2-2-5",
+    topicId: "topic-2-2",
+    userId: "user-2",
+    body: "近所にクラフトビールとコーヒーの専門店がオープンした。昼はコーヒー、夜はビール。居心地が良くて長時間いてしまった。",
+    createdAt: "2026-03-07T16:00:00+09:00",
+  },
+  {
+    id: "act-2-2-6",
+    topicId: "topic-2-2",
+    userId: "user-2",
+    body: "テラス席が桜の木の真下のカフェに行けた！満開の桜を見ながらコーヒーを飲む贅沢。こういう日のためにカフェ巡りをしているといっても過言ではない。",
+    imageUrls: ["https://picsum.photos/seed/sakura-cafe/600/400"],
+    createdAt: "2026-03-21T14:00:00+09:00",
+  },
+];
+
+// ─── topic-2-3: 旅行記（user-2） ──────────────────────────────
+const topic2_3Activities: Activity[] = [
+  {
+    id: "act-2-3-1",
+    topicId: "topic-2-3",
+    userId: "user-2",
+    body: "年末年始に実家の京都へ。元旦の朝5時に伏見稲荷へ行ったら人が少なくて最高だった。千本鳥居を独り占めできる感覚は格別。",
+    imageUrls: ["https://picsum.photos/seed/fushimiinari/600/400"],
+    createdAt: "2026-01-04T20:00:00+09:00",
+  },
+  {
+    id: "act-2-3-2",
+    topicId: "topic-2-3",
+    userId: "user-2",
+    body: "熱海へ日帰り旅行。温泉で肩こりがほぐれて、海鮮丼が美味しくて、帰りに干物を大量に買った。定番コースだけど外れがない。",
+    imageUrls: ["https://picsum.photos/seed/atami/600/400"],
+    createdAt: "2026-02-12T21:30:00+09:00",
+  },
+  {
+    id: "act-2-3-3",
+    topicId: "topic-2-3",
+    userId: "user-2",
+    body: "友達と鎌倉へ。江ノ電に乗って由比ヶ浜まで。夕暮れ時の海辺に座って日が沈むまで話し続けた。こういう時間がいちばん大切だと思う。",
+    imageUrls: ["https://picsum.photos/seed/kamakura/600/400"],
+    createdAt: "2026-03-14T22:00:00+09:00",
+  },
+  {
+    id: "act-2-3-4",
+    topicId: "topic-2-3",
+    userId: "user-2",
+    body: "春休みに台湾旅行の計画をたて始めた。夜市・小籠包・タピオカが主な目的（食べてばかり）。早めに予約しないとフライトが高くなりそう。",
+    createdAt: "2026-03-29T21:00:00+09:00",
+  },
+  {
+    id: "act-2-3-5",
+    topicId: "topic-2-3",
+    userId: "user-2",
+    body: "旅の記録をまとめるノートを買った。スタンプやチケットを貼れるように厚めのページのもの。旅行前から準備するのも旅の楽しみのひとつだと思っている。",
+    createdAt: "2026-03-31T20:00:00+09:00",
+  },
+];
+
+// ─── topic-3-1: ゲーム記録（user-3） ─────────────────────────
+const topic3_1Activities: Activity[] = [
+  {
+    id: "act-3-1-1",
+    topicId: "topic-3-1",
+    userId: "user-3",
+    body: "エルデンリングのDLCを久しぶりにプレイして1周目クリア。マレニアより強いボスが追加されているとは思わなかった。30回は死んだ。",
+    createdAt: "2026-01-07T00:15:00+09:00",
+  },
+  {
+    id: "act-3-1-2",
+    topicId: "topic-3-1",
+    userId: "user-3",
+    body: "Balatraにドハマりした。ローグライク×ポーカーという組み合わせが天才的で、気づいたら3時間経っていた。「もう1回だけ」の罠から抜け出せない。",
+    createdAt: "2026-01-20T01:00:00+09:00",
+  },
+  {
+    id: "act-3-1-3",
+    topicId: "topic-3-1",
+    userId: "user-3",
+    body: "ペルソナ3リロードを開始。リメイク版のグラフィックとUI刷新が凄い。オリジナルも好きだったけど、これはこれで完成度が高い。",
+    createdAt: "2026-02-04T23:30:00+09:00",
+  },
+  {
+    id: "act-3-1-4",
+    topicId: "topic-3-1",
+    userId: "user-3",
+    body: "FF7リバースをリトライ。クリアした。バトルシステムが本当に楽しい。ケアガ連発しながらもなんとか倒した最終決戦、最高だった。",
+    createdAt: "2026-02-19T00:00:00+09:00",
+  },
+  {
+    id: "act-3-1-5",
+    topicId: "topic-3-1",
+    userId: "user-3",
+    body: "パルワールドのアップデートが来たので久しぶりに起動。しばらく離れている間に拠点が壊滅していた笑。でもまたイチから作るのも楽しい。",
+    createdAt: "2026-03-04T22:00:00+09:00",
+  },
+  {
+    id: "act-3-1-6",
+    topicId: "topic-3-1",
+    userId: "user-3",
+    body: "Steamのセールで10本くらい買ってしまった。積みゲーが増える一方だが、セールに罪悪感は今更感じない。積んでいる間が一番楽しいのかもしれない。",
+    createdAt: "2026-03-17T21:30:00+09:00",
+  },
+  {
+    id: "act-3-1-7",
+    topicId: "topic-3-1",
+    userId: "user-3",
+    body: "インディーゲーム「Hollow Knight Silksong」の発売日が発表されたらしいという噂。本当ならもう待ち切れない。Hollow Knightは人生ゲームのひとつ。",
+    createdAt: "2026-03-31T23:00:00+09:00",
+  },
+];
+
+// ─── topic-3-2: アニメ感想（user-3） ────────────────────────
+const topic3_2Activities: Activity[] = [
+  {
+    id: "act-3-2-1",
+    topicId: "topic-3-2",
+    userId: "user-3",
+    body: "「葬送のフリーレン」を最終話まで見た。旅の終わりというより、旅の始まりを描いた物語だと思う。余韻がすごく心地よかった。",
+    createdAt: "2026-01-09T23:30:00+09:00",
+  },
+  {
+    id: "act-3-2-2",
+    topicId: "topic-3-2",
+    userId: "user-3",
+    body: "「ダンジョン飯」アニメ版が始まった。原作ファンとしてキャラクターデザインと作画クオリティに感動。特にマルシルの表情が原作そのままで嬉しい。",
+    createdAt: "2026-01-23T23:00:00+09:00",
+  },
+  {
+    id: "act-3-2-3",
+    topicId: "topic-3-2",
+    userId: "user-3",
+    body: "「BLUE GIANT」のアニメ映画を視聴。友人に強く勧められて観たら予想以上だった。音楽の熱量をアニメで表現する試みが新鮮で、演奏シーンで何度か鳥肌が立った。",
+    createdAt: "2026-02-20T22:30:00+09:00",
+  },
+  {
+    id: "act-3-2-4",
+    topicId: "topic-3-2",
+    userId: "user-3",
+    body: "今期は当たりが多い。マッシュル、ダンまち、あと配信でいくつか。個人的にダークホースはマッシュル。バトルの演出が毎週面白い。",
+    createdAt: "2026-03-06T23:30:00+09:00",
+  },
+  {
+    id: "act-3-2-5",
+    topicId: "topic-3-2",
+    userId: "user-3",
+    body: "「推しの子」2期を見直した。初見とアクアの動機を知っている状態での2週目は全然印象が違う。1話から布石があちこちに散りばめられている。",
+    createdAt: "2026-03-19T22:00:00+09:00",
+  },
+];
+
+// ─── topic-3-3: 筋トレログ（user-3） ─────────────────────────
+const topic3_3Activities: Activity[] = [
+  {
+    id: "act-3-3-1",
+    topicId: "topic-3-3",
+    userId: "user-3",
+    body: "新年から筋トレ再開。年末年始でだいぶ落ちていた。ベンチプレスはMAX80kgだったが今日はウォームアップで65kgがきつかった。地道に戻していく。",
+    createdAt: "2026-01-06T21:00:00+09:00",
+  },
+  {
+    id: "act-3-3-2",
+    topicId: "topic-3-3",
+    userId: "user-3",
+    body: "胸の日。ベンチプレス 5×5 (70kg)。最後のセットが限界ギリギリだった。プロテインを飲み忘れたのと睡眠不足が原因かも。",
+    createdAt: "2026-01-21T22:30:00+09:00",
+  },
+  {
+    id: "act-3-3-3",
+    topicId: "topic-3-3",
+    userId: "user-3",
+    body: "背中の日。デッドリフト初挑戦で100kgを引けた。腰が少し怖かったのでフォームをYouTubeで確認してからにすればよかった。次回は確認してから挑む。",
+    createdAt: "2026-02-03T21:30:00+09:00",
+  },
+  {
+    id: "act-3-3-4",
+    topicId: "topic-3-3",
+    userId: "user-3",
+    body: "肩・腕の日。サイドレイズを6kg→8kgに増量。フォーム崩さずにできた。肩は怪我しやすい部位なのでフォーム重視で丁寧に続けたい。",
+    createdAt: "2026-02-17T22:00:00+09:00",
+  },
+  {
+    id: "act-3-3-5",
+    topicId: "topic-3-3",
+    userId: "user-3",
+    body: "ベンチプレスで75kg×3本上がった！年明けから徐々に戻ってきた。80kgへの復帰が見えてきた感じがする。",
+    createdAt: "2026-03-03T21:00:00+09:00",
+  },
+  {
+    id: "act-3-3-6",
+    topicId: "topic-3-3",
+    userId: "user-3",
+    body: "体重73.2kg、体脂肪率16.8%。目標は体脂肪13%台。筋肉量が増えてきているのに体脂肪も下がっているのでいい傾向。あと少し。",
+    createdAt: "2026-03-17T22:00:00+09:00",
+  },
+  {
+    id: "act-3-3-7",
+    topicId: "topic-3-3",
+    userId: "user-3",
+    body: "スクワット90kgで膝が少し痛くなってきた。深さを見直してしゃがみすぎていた可能性。重量より膝の健康が先決なので少し下げて様子を見る。",
+    createdAt: "2026-03-29T21:30:00+09:00",
+  },
+];
+
+// ─── topic-3-4: 技術メモ（user-3） ───────────────────────────
+const topic3_4Activities: Activity[] = [
+  {
+    id: "act-3-4-1",
+    topicId: "topic-3-4",
+    userId: "user-3",
+    body: "ReactのuseCallbackとuseMemoの使い分けをやっと腑に落として理解した気がする。「参照の同一性を保つ」というキーワードで整理できた。useCallbackは関数、useMemoは計算結果。",
+    createdAt: "2026-01-14T23:30:00+09:00",
+  },
+  {
+    id: "act-3-4-2",
+    topicId: "topic-3-4",
+    userId: "user-3",
+    body: "TypeScriptのsatisfiesオペレーターが便利すぎる。今まで `as` でごまかしていた部分が型安全に書けるようになった。特にオブジェクトのプロパティ補完と型チェックが同時にできるのが最高。",
+    createdAt: "2026-01-28T23:00:00+09:00",
+  },
+  {
+    id: "act-3-4-3",
+    topicId: "topic-3-4",
+    userId: "user-3",
+    body: "Turborepoでモノレポを試した。ビルドキャッシュが効くとCIの時間が半分以下になった。複数パッケージを抱えるプロジェクトには必須ツールになりそう。",
+    createdAt: "2026-02-11T22:30:00+09:00",
+  },
+  {
+    id: "act-3-4-4",
+    topicId: "topic-3-4",
+    userId: "user-3",
+    body: "Dockerのマルチステージビルドを導入してイメージサイズを1.2GB→480MBに削減できた。node_modulesを本番イメージに含めない構成にするだけでこんなに変わるとは。",
+    createdAt: "2026-02-25T22:00:00+09:00",
+  },
+  {
+    id: "act-3-4-5",
+    topicId: "topic-3-4",
+    userId: "user-3",
+    body: "shadcn/uiを使い始めた。「コンポーネントをコピペして自分のコードベースに取り込む」思想、最初は違和感があったけど使い始めると非常に理にかなっている。カスタマイズが自由自在。",
+    createdAt: "2026-03-10T23:00:00+09:00",
+  },
+];
+
+// ─── topic-4-1: 料理レシピ（user-4） ─────────────────────────
+const topic4_1Activities: Activity[] = [
+  {
+    id: "act-4-1-1",
+    topicId: "topic-4-1",
+    userId: "user-4",
+    body: "鶏の唐揚げのベスト配合が固まった。下味は醤油・酒・みりん・生姜・にんにく、30分以上漬け込む。カリカリにするため170℃で揚げてから200℃で二度揚げ。",
+    imageUrls: ["https://picsum.photos/seed/karaage/600/400"],
+    createdAt: "2026-01-05T20:30:00+09:00",
+  },
+  {
+    id: "act-4-1-2",
+    topicId: "topic-4-1",
+    userId: "user-4",
+    body: "市販のルーを使わないビーフシチューに挑戦。デミグラスソース缶＋赤ワイン＋トマトピューレで作ったら本格的な味になった。翌日はクロワッサンに合わせて召し上がれ。",
+    imageUrls: ["https://picsum.photos/seed/stew/600/400"],
+    createdAt: "2026-01-18T21:00:00+09:00",
+  },
+  {
+    id: "act-4-1-3",
+    topicId: "topic-4-1",
+    userId: "user-4",
+    body: "バレンタインに向けてトリュフチョコに挑戦。ガナッシュの硬さの調整が難しく、柔らかくなりすぎて丸めるので一苦労。でも味は最高だった。",
+    imageUrls: ["https://picsum.photos/seed/truffle/600/400"],
+    createdAt: "2026-02-01T22:00:00+09:00",
+  },
+  {
+    id: "act-4-1-4",
+    topicId: "topic-4-1",
+    userId: "user-4",
+    body: "ベイクドチーズケーキ。クリームチーズ300gをたっぷり使ったら濃厚すぎて最高だった。底のビスケット土台はバターで固めるとしっかりした食感になる。",
+    imageUrls: ["https://picsum.photos/seed/cheesecake/600/400"],
+    createdAt: "2026-02-15T20:00:00+09:00",
+  },
+  {
+    id: "act-4-1-5",
+    topicId: "topic-4-1",
+    userId: "user-4",
+    body: "春のお弁当用に菜の花のからし和えを作った。ほろ苦さが春らしくていい。からし多めが好みの人向けかも。",
+    createdAt: "2026-02-28T19:00:00+09:00",
+  },
+  {
+    id: "act-4-1-6",
+    topicId: "topic-4-1",
+    userId: "user-4",
+    body: "ちらし寿司用の酢飯の黄金比率についにたどり着いた。米2合に対して：酢大さじ3、砂糖大さじ2強、塩小さじ1弱。砂糖多め・塩少なめがポイント。",
+    imageUrls: ["https://picsum.photos/seed/chirashi/600/400"],
+    createdAt: "2026-03-14T20:30:00+09:00",
+  },
+  {
+    id: "act-4-1-7",
+    topicId: "topic-4-1",
+    userId: "user-4",
+    body: "いちごのショートケーキ。スポンジが想像以上にふわふわに仕上がって満足。生クリームは泡立てすぎると分離するので八分立てで止めること。来年も作りたい。",
+    imageUrls: ["https://picsum.photos/seed/shortcake/600/400"],
+    createdAt: "2026-03-27T21:00:00+09:00",
+  },
+];
+
+// ─── topic-4-2: 映画・ドラマ（user-4） ──────────────────────
+const topic4_2Activities: Activity[] = [
+  {
+    id: "act-4-2-1",
+    topicId: "topic-4-2",
+    userId: "user-4",
+    body: "「逃げるは恥だが役に立つ」を見返した。時代を感じるセリフも混じっているけど、それも含めて2016年のドラマとして今見ると面白い。みくりさんの言語化力が好き。",
+    createdAt: "2026-01-12T23:00:00+09:00",
+  },
+  {
+    id: "act-4-2-2",
+    topicId: "topic-4-2",
+    userId: "user-4",
+    body: "『ミッドサマー』を初鑑賞。北欧の明るい陽光の中で進む恐怖という逆説的な演出が巧みだった。怖かったけどビジュアルが美しくて、不思議な達成感がある映画。",
+    createdAt: "2026-01-27T22:30:00+09:00",
+  },
+  {
+    id: "act-4-2-3",
+    topicId: "topic-4-2",
+    userId: "user-4",
+    body: "大河ドラマ「光る君へ」が面白い。藤原道長が権力者でありながら人間的な弱さも持ち合わせているキャラクター像が今まで見てきた大河と違う。",
+    createdAt: "2026-02-23T22:00:00+09:00",
+  },
+  {
+    id: "act-4-2-4",
+    topicId: "topic-4-2",
+    userId: "user-4",
+    body: "映画「ミッドナイト・イン・パリ」を再視聴。ウディ・アレンの映画はパリが本当に美しく映る。1920年代のパリにタイムスリップする設定がロマンチックで毎回好きになる。",
+    createdAt: "2026-03-08T23:00:00+09:00",
+  },
+  {
+    id: "act-4-2-5",
+    topicId: "topic-4-2",
+    userId: "user-4",
+    body: "Netflixドラマ「BEEF」を一気見。道路上のトラブルから始まる2人の因縁を描いた作品で、韓系アメリカ人の主人公に感情移入しすぎてしんどくなった笑。でも名作。",
+    createdAt: "2026-03-22T00:00:00+09:00",
+  },
+];
+
+// ─── topic-4-3: 植物育成（user-4） ───────────────────────────
+const topic4_3Activities: Activity[] = [
+  {
+    id: "act-4-3-1",
+    topicId: "topic-4-3",
+    userId: "user-4",
+    body: "多肉植物の冬越し中。水やりを月1回に絞った。葉が少しシワシワになってきたのが心配だけど、休眠しているだけなので春まで待つ。",
+    imageUrls: ["https://picsum.photos/seed/succulent/600/400"],
+    createdAt: "2026-01-10T17:00:00+09:00",
+  },
+  {
+    id: "act-4-3-2",
+    topicId: "topic-4-3",
+    userId: "user-4",
+    body: "モンステラの新葉が展開してきた！冬なのに生命力が強すぎる。ハート形の葉が根拠なく元気を与えてくれる。窓際の日当たりが良い場所にして正解だった。",
+    imageUrls: ["https://picsum.photos/seed/monstera/600/400"],
+    createdAt: "2026-01-24T18:30:00+09:00",
+  },
+  {
+    id: "act-4-3-3",
+    topicId: "topic-4-3",
+    userId: "user-4",
+    body: "春の開花に向けてラナンキュラスの球根を5球植え込んだ。球根を水に少し濡らして戻してから植えるのがコツらしい。3月〜4月の開花が楽しみ。",
+    createdAt: "2026-02-07T16:00:00+09:00",
+  },
+  {
+    id: "act-4-3-4",
+    topicId: "topic-4-3",
+    userId: "user-4",
+    body: "多肉のパキフィツム系の葉挿しに成功した。親葉からちっちゃい芽が出てきているのを発見した時の感動は毎回ある。育てている実感が得られる瞬間。",
+    imageUrls: ["https://picsum.photos/seed/pachyphytum/600/400"],
+    createdAt: "2026-02-21T17:30:00+09:00",
+  },
+  {
+    id: "act-4-3-5",
+    topicId: "topic-4-3",
+    userId: "user-4",
+    body: "ラナンキュラスが咲き始めた！赤・オレンジ・黄色の3色が混じってとても鮮やか。薄紙のような花びらが幾重にも重なる形がとにかく好き。",
+    imageUrls: ["https://picsum.photos/seed/ranunculus/600/400"],
+    createdAt: "2026-03-05T15:30:00+09:00",
+  },
+  {
+    id: "act-4-3-6",
+    topicId: "topic-4-3",
+    userId: "user-4",
+    body: "ベランダガーデニングをもう少し本格的にやろうと計画中。ハーブを育てて料理に使うのが目標。バジル・ミント・ローズマリー辺りから始めたい。",
+    createdAt: "2026-03-20T19:00:00+09:00",
+  },
+  {
+    id: "act-4-3-7",
+    topicId: "topic-4-3",
+    userId: "user-4",
+    body: "ミントとバジルの種を蒔いた。発芽まで1週間前後かかるらしい。毎朝霧吹きで水やりしながら育てるのが今の楽しみになっている。",
+    imageUrls: ["https://picsum.photos/seed/seedlings/600/400"],
+    createdAt: "2026-03-31T18:00:00+09:00",
+  },
+];
+
+export const activities: Activity[] = [
+  ...topic1_1Activities,
+  ...topic1_2Activities,
+  ...topic1_3Activities,
+  ...topic1_4Activities,
+  ...topic2_1Activities,
+  ...topic2_2Activities,
+  ...topic2_3Activities,
+  ...topic3_1Activities,
+  ...topic3_2Activities,
+  ...topic3_3Activities,
+  ...topic3_4Activities,
+  ...topic4_1Activities,
+  ...topic4_2Activities,
+  ...topic4_3Activities,
+];

--- a/src/mocks/topics.ts
+++ b/src/mocks/topics.ts
@@ -1,0 +1,106 @@
+import { type Topic } from "@/types/topic";
+
+// user-1（山田 太郎）のトピック
+const user1Topics: Topic[] = [
+  {
+    id: "topic-1-1",
+    userId: "user-1",
+    title: "読書",
+    imageUrl: "https://picsum.photos/seed/books/400/200",
+  },
+  {
+    id: "topic-1-2",
+    userId: "user-1",
+    title: "映画",
+    imageUrl: "https://picsum.photos/seed/movie/400/200",
+  },
+  {
+    id: "topic-1-3",
+    userId: "user-1",
+    title: "料理日記",
+    imageUrl: "https://picsum.photos/seed/cooking/400/200",
+  },
+  {
+    id: "topic-1-4",
+    userId: "user-1",
+    title: "今日の出来事",
+  },
+];
+
+// user-2（佐藤 花子）のトピック
+const user2Topics: Topic[] = [
+  {
+    id: "topic-2-1",
+    userId: "user-2",
+    title: "読んだ本",
+    imageUrl: "https://picsum.photos/seed/hanako-books/400/200",
+  },
+  {
+    id: "topic-2-2",
+    userId: "user-2",
+    title: "カフェ巡り",
+    imageUrl: "https://picsum.photos/seed/cafe/400/200",
+  },
+  {
+    id: "topic-2-3",
+    userId: "user-2",
+    title: "旅行記",
+    imageUrl: "https://picsum.photos/seed/travel/400/200",
+  },
+];
+
+// user-3（鈴木 一郎）のトピック
+const user3Topics: Topic[] = [
+  {
+    id: "topic-3-1",
+    userId: "user-3",
+    title: "ゲーム記録",
+    imageUrl: "https://picsum.photos/seed/game/400/200",
+  },
+  {
+    id: "topic-3-2",
+    userId: "user-3",
+    title: "アニメ感想",
+    imageUrl: "https://picsum.photos/seed/anime/400/200",
+  },
+  {
+    id: "topic-3-3",
+    userId: "user-3",
+    title: "筋トレログ",
+    imageUrl: "https://picsum.photos/seed/gym/400/200",
+  },
+  {
+    id: "topic-3-4",
+    userId: "user-3",
+    title: "技術メモ",
+  },
+];
+
+// user-4（田中 美咲）のトピック
+const user4Topics: Topic[] = [
+  {
+    id: "topic-4-1",
+    userId: "user-4",
+    title: "料理レシピ",
+    imageUrl: "https://picsum.photos/seed/recipe/400/200",
+  },
+  {
+    id: "topic-4-2",
+    userId: "user-4",
+    title: "映画・ドラマ",
+    imageUrl: "https://picsum.photos/seed/drama/400/200",
+  },
+  {
+    id: "topic-4-3",
+    userId: "user-4",
+    title: "植物育成",
+    imageUrl: "https://picsum.photos/seed/plants/400/200",
+  },
+];
+
+export const topics: Topic[] = [
+  ...user1Topics,
+  ...user2Topics,
+  ...user3Topics,
+  ...user4Topics,
+];

--- a/src/mocks/users.ts
+++ b/src/mocks/users.ts
@@ -1,0 +1,30 @@
+import { type User } from "@/types/user";
+
+export const currentUser: User = {
+  id: "user-1",
+  name: "山田 太郎",
+  avatarUrl: "https://i.pravatar.cc/150?u=user-1",
+  badge: "🌟",
+};
+
+export const users: User[] = [
+  currentUser,
+  {
+    id: "user-2",
+    name: "佐藤 花子",
+    avatarUrl: "https://i.pravatar.cc/150?u=user-2",
+    badge: "📚",
+  },
+  {
+    id: "user-3",
+    name: "鈴木 一郎",
+    avatarUrl: "https://i.pravatar.cc/150?u=user-3",
+    badge: "🎮",
+  },
+  {
+    id: "user-4",
+    name: "田中 美咲",
+    avatarUrl: "https://i.pravatar.cc/150?u=user-4",
+    badge: "🍳",
+  },
+];


### PR DESCRIPTION
## 概要

Issue #3 対応。バックエンドの代わりに使う静的モックデータを作成しました。
プレゼンで「リアルに使われている感」が出るよう、データの内容・量・日付分散にこだわっています。

## 変更内容

- `src/mocks/users.ts` — `currentUser`（山田 太郎）+ 他 3 名のユーザー一覧
- `src/mocks/topics.ts` — 各ユーザー 3〜4 個、計 14 トピック
- `src/mocks/activities.ts` — 各トピック 5〜7 件、計 86 アクティビティ

## データ構成

### ユーザー（4名）

| id | name | badge |
|---|---|---|
| user-1（currentUser） | 山田 太郎 | 🌟 |
| user-2 | 佐藤 花子 | 📚 |
| user-3 | 鈴木 一郎 | 🎮 |
| user-4 | 田中 美咲 | 🍳 |

### トピック（14個）

| ユーザー | トピック |
|---|---|
| 山田 太郎 | 読書 / 映画 / 料理日記 / 今日の出来事 |
| 佐藤 花子 | 読んだ本 / カフェ巡り / 旅行記 |
| 鈴木 一郎 | ゲーム記録 / アニメ感想 / 筋トレログ / 技術メモ |
| 田中 美咲 | 料理レシピ / 映画・ドラマ / 植物育成 |

### アクティビティの特徴

- 内容は「実際に書きそうなこと」を意識（読書感想・料理メモ・筋トレ記録など）
- `createdAt` は 2026-01〜2026-03 の 3 ヶ月に分散（振り返りタイルが映えるよう均等に配置）
- 一部アクティビティは `imageUrls` あり（picsum.photos のプレースホルダー）
- アバター画像は `https://i.pravatar.cc/150?u={id}` を使用

## チェックリスト

- [x] `any` 型を使用していない
- [x] `interface` ではなく `type` を使用している（`import { type ... }`）
- [x] `src/mocks/` に配置している
- [x] 各トピック 5 件以上のアクティビティがある
- [x] `createdAt` は ISO 8601 形式（タイムゾーン付き）
- [x] TypeScript エラーなし（`tsc --noEmit`）
- [x] ESLint エラーなし

## 関連 Issue

Closes #3

## 依存 PR

#2（User / Topic / Activity の型定義）がマージ済みであることが前提
