### PR TITLE
feat: ホーム画面を実装する (#5)

### DIFF
--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -1,64 +1,15 @@
-import Image from "next/image";
+import ActivityFeed from "@/components/home/ActivityFeed";
 
 export default function Home() {
   return (
-    <div className="flex flex-col flex-1 items-center justify-center bg-zinc-50 font-sans dark:bg-black">
-      <main className="flex flex-1 w-full max-w-3xl flex-col items-center justify-between py-32 px-16 bg-white dark:bg-black sm:items-start">
-        <Image
-          className="dark:invert"
-          src="/next.svg"
-          alt="Next.js logo"
-          width={100}
-          height={20}
-          priority
-        />
-        <div className="flex flex-col items-center gap-6 text-center sm:items-start sm:text-left">
-          <h1 className="max-w-xs text-3xl font-semibold leading-10 tracking-tight text-black dark:text-zinc-50">
-            To get started, edit the page.tsx file.
-          </h1>
-          <p className="max-w-md text-lg leading-8 text-zinc-600 dark:text-zinc-400">
-            Looking for a starting point or more instructions? Head over to{" "}
-            <a
-              href="https://vercel.com/templates?framework=next.js&utm_source=create-next-app&utm_medium=appdir-template-tw&utm_campaign=create-next-app"
-              className="font-medium text-zinc-950 dark:text-zinc-50"
-            >
-              Templates
-            </a>{" "}
-            or the{" "}
-            <a
-              href="https://nextjs.org/learn?utm_source=create-next-app&utm_medium=appdir-template-tw&utm_campaign=create-next-app"
-              className="font-medium text-zinc-950 dark:text-zinc-50"
-            >
-              Learning
-            </a>{" "}
-            center.
-          </p>
-        </div>
-        <div className="flex flex-col gap-4 text-base font-medium sm:flex-row">
-          <a
-            className="flex h-12 w-full items-center justify-center gap-2 rounded-full bg-foreground px-5 text-background transition-colors hover:bg-[#383838] dark:hover:bg-[#ccc] md:w-[158px]"
-            href="https://vercel.com/new?utm_source=create-next-app&utm_medium=appdir-template-tw&utm_campaign=create-next-app"
-            target="_blank"
-            rel="noopener noreferrer"
-          >
-            <Image
-              className="dark:invert"
-              src="/vercel.svg"
-              alt="Vercel logomark"
-              width={16}
-              height={16}
-            />
-            Deploy Now
-          </a>
-          <a
-            className="flex h-12 w-full items-center justify-center rounded-full border border-solid border-black/[.08] px-5 transition-colors hover:border-transparent hover:bg-black/[.04] dark:border-white/[.145] dark:hover:bg-[#1a1a1a] md:w-[158px]"
-            href="https://nextjs.org/docs?utm_source=create-next-app&utm_medium=appdir-template-tw&utm_campaign=create-next-app"
-            target="_blank"
-            rel="noopener noreferrer"
-          >
-            Documentation
-          </a>
-        </div>
+    <div className="flex flex-col">
+      {/* スティッキーヘッダー */}
+      <header className="sticky top-0 z-10 border-b border-zinc-800 bg-zinc-950/80 px-4 py-3 backdrop-blur-sm">
+        <h1 className="text-lg font-bold text-zinc-100">ホーム</h1>
+      </header>
+
+      <main className="px-4 py-4">
+        <ActivityFeed />
       </main>
     </div>
   );

--- a/src/components/home/ActivityCard.tsx
+++ b/src/components/home/ActivityCard.tsx
@@ -1,0 +1,27 @@
+import { type Activity } from "@/types/activity";
+import { type Topic } from "@/types/topic";
+import { type User } from "@/types/user";
+import UIActivityCard from "@/components/ui/ActivityCard";
+
+type Props = {
+  activity: Activity;
+  topic: Topic;
+  user: User;
+};
+
+/**
+ * ホーム画面用の ActivityCard。
+ * ui/ActivityCard にトピック情報を解決して渡すラッパー。
+ */
+const ActivityCard = ({ activity, topic, user }: Props) => {
+  return (
+    <UIActivityCard
+      activity={activity}
+      user={user}
+      topicTitle={topic.title}
+      topicId={topic.id}
+    />
+  );
+};
+
+export default ActivityCard;

--- a/src/components/home/ActivityFeed.tsx
+++ b/src/components/home/ActivityFeed.tsx
@@ -1,0 +1,49 @@
+import { activities } from "@/mocks/activities";
+import { topics } from "@/mocks/topics";
+import { currentUser } from "@/mocks/users";
+import ActivityCard from "./ActivityCard";
+
+/**
+ * ホームフィード。
+ * currentUser のアクティビティを時系列降順（最新が先頭）で表示する。
+ */
+const ActivityFeed = () => {
+  // currentUser のアクティビティを新しい順に並べる
+  const myActivities = activities
+    .filter((a) => a.userId === currentUser.id)
+    .sort(
+      (a, b) =>
+        new Date(b.createdAt).getTime() - new Date(a.createdAt).getTime(),
+    );
+
+  // トピックを O(1) で引けるようにマップ化
+  const topicMap = new Map(topics.map((t) => [t.id, t]));
+
+  if (myActivities.length === 0) {
+    return (
+      <p className="text-center text-sm text-zinc-500 py-16">
+        アクティビティがありません
+      </p>
+    );
+  }
+
+  return (
+    <ul className="flex flex-col gap-3">
+      {myActivities.map((activity) => {
+        const topic = topicMap.get(activity.topicId);
+        if (!topic) return null;
+        return (
+          <li key={activity.id}>
+            <ActivityCard
+              activity={activity}
+              topic={topic}
+              user={currentUser}
+            />
+          </li>
+        );
+      })}
+    </ul>
+  );
+};
+
+export default ActivityFeed;


### PR DESCRIPTION
## 概要

Issue #5 の実装です。
自分が書いたアクティビティの時系列フィードを表示するホーム画面を実装しました。

## 変更ファイル

| ファイル | 変更内容 |
|---|---|
| `src/app/page.tsx` | スティッキーヘッダー付きのホーム画面に全面更新 |
| `src/components/home/ActivityFeed.tsx` | フィード全体コンポーネントを新規作成 |
| `src/components/home/ActivityCard.tsx` | `ui/ActivityCard` ラッパーを新規作成 |

## 実装内容

- `currentUser`（user-1）のアクティビティを `activities` モックからフィルタリングし、`createdAt` 降順（最新が先頭）で表示
- 各アクティビティに `TopicChip` でトピック名を表示（`ui/ActivityCard` 経由）
- 本文 200 文字超は折りたたんで「もっと見る」ボタンで展開（`ui/ActivityCard` 実装済みの機能を利用）
- 画像がある場合はサムネイル表示（同上）
- アクティビティが 0 件の場合は「アクティビティがありません」メッセージを表示

## AC 達成確認

- [x] モックデータから自分の全トピックのアクティビティを時系列順で表示
- [x] 各アクティビティにトピック名（TopicChip）を表示
- [x] 本文が長い場合（200 文字超）は折りたたみ、「もっと見る」ボタンで展開
- [x] 画像がある場合はサムネイル表示

## 依存 Issue

- Close #5
