### PR TITLE
feat: 【画面】プロフィール画面（振り返りタイル）を実装する (#7)

### DIFF
--- a/src/app/profile/page.tsx
+++ b/src/app/profile/page.tsx
@@ -1,0 +1,31 @@
+import { currentUser } from "@/mocks/users";
+import { topics } from "@/mocks/topics";
+import { activities } from "@/mocks/activities";
+import UserInfo from "@/components/profile/UserInfo";
+import TopicList from "@/components/profile/TopicList";
+import ActivityTileCalendar from "@/components/profile/ActivityTileCalendar";
+
+const ProfilePage = () => {
+  // currentUser のトピックとアクティビティのみ抽出
+  const myTopics = topics.filter((t) => t.userId === currentUser.id);
+  const myActivities = activities.filter((a) => a.userId === currentUser.id);
+
+  return (
+    <main className="flex flex-col gap-6 pb-6">
+      {/* ユーザー情報 */}
+      <UserInfo
+        user={currentUser}
+        topicCount={myTopics.length}
+        activityCount={myActivities.length}
+      />
+
+      {/* 振り返りタイル */}
+      <ActivityTileCalendar activities={myActivities} />
+
+      {/* トピック一覧 */}
+      <TopicList topics={myTopics} />
+    </main>
+  );
+};
+
+export default ProfilePage;

--- a/src/components/profile/ActivityTileCalendar.tsx
+++ b/src/components/profile/ActivityTileCalendar.tsx
@@ -1,0 +1,237 @@
+"use client";
+
+import { useState, useMemo } from "react";
+import { type Activity } from "@/types/activity";
+import { cn } from "@/lib/utils";
+
+type ActivityTileCalendarProps = {
+  activities: Activity[];
+};
+
+// カレンダーの基準日（モックデータの「現在」 = 2026/04/01）
+const REFERENCE_DATE = new Date("2026-04-01");
+
+const DAY_LABELS = ["日", "月", "火", "水", "木", "金", "土"] as const;
+
+/** 1日の投稿数に応じた 5 段階カラークラスを返す */
+const getColorClass = (count: number): string => {
+  if (count === 0) return "bg-zinc-800";
+  if (count === 1) return "bg-green-200";
+  if (count <= 3) return "bg-green-400";
+  if (count <= 5) return "bg-green-500";
+  return "bg-green-700";
+};
+
+/** Date を "yyyy-MM-dd" キーへ変換 */
+const toDateKey = (date: Date): string => {
+  const y = date.getFullYear();
+  const m = String(date.getMonth() + 1).padStart(2, "0");
+  const d = String(date.getDate()).padStart(2, "0");
+  return `${y}-${m}-${d}`;
+};
+
+/** ISO 8601 文字列の先頭 10 文字（yyyy-MM-dd）を取得 */
+const isoToDateKey = (iso: string): string => iso.slice(0, 10);
+
+type WeekData = {
+  days: Array<{ date: Date; key: string; count: number }>;
+  startDate: Date;
+  endDate: Date;
+};
+
+const ActivityTileCalendar = ({ activities }: ActivityTileCalendarProps) => {
+  const [selectedWeekIdx, setSelectedWeekIdx] = useState<number | null>(null);
+
+  // 52 週分のデータを構築
+  const weeks = useMemo<WeekData[]>(() => {
+    const today = new Date(REFERENCE_DATE);
+    const dayOfWeek = today.getDay(); // 0=日曜
+    const sundayOfThisWeek = new Date(today);
+    sundayOfThisWeek.setDate(today.getDate() - dayOfWeek);
+
+    // 52 週前の日曜日をカレンダー開始日とする
+    const startSunday = new Date(sundayOfThisWeek);
+    startSunday.setDate(sundayOfThisWeek.getDate() - 51 * 7);
+
+    // 日ごとのアクティビティ件数マップを作成
+    const countMap: Record<string, number> = {};
+    for (const act of activities) {
+      const key = isoToDateKey(act.createdAt);
+      countMap[key] = (countMap[key] ?? 0) + 1;
+    }
+
+    const result: WeekData[] = [];
+    for (let w = 0; w < 52; w++) {
+      const days: WeekData["days"] = [];
+      for (let d = 0; d < 7; d++) {
+        const date = new Date(startSunday);
+        date.setDate(startSunday.getDate() + w * 7 + d);
+        const key = toDateKey(date);
+        days.push({ date, key, count: countMap[key] ?? 0 });
+      }
+      result.push({
+        days,
+        startDate: days[0].date,
+        endDate: days[6].date,
+      });
+    }
+    return result;
+  }, [activities]);
+
+  // 月ラベルの位置（週の開始日が月初めなら表示）
+  const monthLabels = useMemo(() => {
+    const labels: Record<number, string> = {};
+    let lastMonth = -1;
+    weeks.forEach((week, idx) => {
+      const month = week.startDate.getMonth();
+      if (month !== lastMonth) {
+        labels[idx] = `${month + 1}月`;
+        lastMonth = month;
+      }
+    });
+    return labels;
+  }, [weeks]);
+
+  // 選択週のアクティビティを降順で取得
+  const selectedWeekActivities = useMemo<Activity[]>(() => {
+    if (selectedWeekIdx === null) return [];
+    const week = weeks[selectedWeekIdx];
+    const startKey = toDateKey(week.startDate);
+    const endKey = toDateKey(week.endDate);
+    return [...activities]
+      .filter((act) => {
+        const key = isoToDateKey(act.createdAt);
+        return key >= startKey && key <= endKey;
+      })
+      .sort((a, b) => b.createdAt.localeCompare(a.createdAt));
+  }, [selectedWeekIdx, weeks, activities]);
+
+  const handleWeekClick = (wIdx: number) => {
+    setSelectedWeekIdx((prev) => (prev === wIdx ? null : wIdx));
+  };
+
+  return (
+    <section className="px-4">
+      <h2 className="mb-3 text-sm font-semibold uppercase tracking-wider text-zinc-500">
+        振り返り
+      </h2>
+
+      {/* カレンダー本体（横スクロール） */}
+      <div className="overflow-x-auto rounded-xl bg-zinc-800/40 p-3 pb-4">
+        {/* 月ラベル行 */}
+        <div className="flex gap-[2px] mb-1 pl-[26px]">
+          {weeks.map((_, wIdx) => (
+            <div
+              key={wIdx}
+              className="flex-shrink-0 w-[13px]"
+            >
+              {monthLabels[wIdx] && (
+                <span className="text-[9px] leading-none text-zinc-500">
+                  {monthLabels[wIdx]}
+                </span>
+              )}
+            </div>
+          ))}
+        </div>
+
+        {/* 曜日ラベル + セルグリッド */}
+        <div className="flex items-start gap-[6px]">
+          {/* 曜日ラベル（月・水・金 のみ表示） */}
+          <div className="flex flex-col flex-shrink-0 gap-[2px]">
+            {DAY_LABELS.map((label, i) => (
+              <div
+                key={i}
+                className="w-[18px] h-[11px] flex items-center justify-end"
+              >
+                {(i === 1 || i === 3 || i === 5) && (
+                  <span className="text-[9px] leading-none text-zinc-500">
+                    {label}
+                  </span>
+                )}
+              </div>
+            ))}
+          </div>
+
+          {/* 週 × 日 のセル群 */}
+          <div className="flex gap-[2px]">
+            {weeks.map((week, wIdx) => {
+              const isSelected = selectedWeekIdx === wIdx;
+              return (
+                <button
+                  key={wIdx}
+                  type="button"
+                  aria-label={`${toDateKey(week.startDate)} の週`}
+                  onClick={() => handleWeekClick(wIdx)}
+                  className="flex flex-col flex-shrink-0 gap-[2px] w-[11px] focus:outline-none"
+                >
+                  {week.days.map((day) => (
+                    <div
+                      key={day.key}
+                      title={`${day.key}: ${day.count}件`}
+                      className={cn(
+                        "w-[11px] h-[11px] rounded-sm transition-all",
+                        getColorClass(day.count),
+                        isSelected
+                          ? "ring-1 ring-violet-400 ring-offset-1 ring-offset-zinc-900"
+                          : "hover:brightness-110",
+                      )}
+                    />
+                  ))}
+                </button>
+              );
+            })}
+          </div>
+        </div>
+
+        {/* 凡例 */}
+        <div className="flex items-center justify-end gap-[3px] mt-2.5">
+          <span className="text-[9px] text-zinc-500 mr-1">少</span>
+          {(["bg-zinc-800", "bg-green-200", "bg-green-400", "bg-green-500", "bg-green-700"] as const).map(
+            (cls, i) => (
+              <div
+                key={i}
+                className={cn("w-[11px] h-[11px] rounded-sm", cls)}
+              />
+            ),
+          )}
+          <span className="text-[9px] text-zinc-500 ml-1">多</span>
+        </div>
+      </div>
+
+      {/* 選択週のアクティビティ一覧 */}
+      {selectedWeekIdx !== null && (
+        <div className="mt-4">
+          <p className="mb-2 text-xs text-zinc-500">
+            {toDateKey(weeks[selectedWeekIdx].startDate).replace(/-/g, "/")}{" "}
+            〜{" "}
+            {toDateKey(weeks[selectedWeekIdx].endDate).replace(/-/g, "/")}
+            の記録
+          </p>
+          {selectedWeekActivities.length === 0 ? (
+            <p className="rounded-xl bg-zinc-800/40 p-4 text-center text-sm text-zinc-500">
+              この週には記録がありません
+            </p>
+          ) : (
+            <ul className="flex flex-col gap-2">
+              {selectedWeekActivities.map((act) => (
+                <li
+                  key={act.id}
+                  className="rounded-xl bg-zinc-800/60 p-3 text-sm"
+                >
+                  <p className="mb-1 text-xs text-zinc-500">
+                    {isoToDateKey(act.createdAt).replace(/-/g, "/")}
+                  </p>
+                  <p className="line-clamp-3 leading-relaxed text-zinc-200">
+                    {act.body}
+                  </p>
+                </li>
+              ))}
+            </ul>
+          )}
+        </div>
+      )}
+    </section>
+  );
+};
+
+export default ActivityTileCalendar;

--- a/src/components/profile/TopicList.tsx
+++ b/src/components/profile/TopicList.tsx
@@ -1,0 +1,38 @@
+import Link from "next/link";
+import { type Topic } from "@/types/topic";
+
+type TopicListProps = {
+  topics: Topic[];
+};
+
+const TopicList = ({ topics }: TopicListProps) => {
+  return (
+    <section className="px-4">
+      <h2 className="mb-3 text-sm font-semibold uppercase tracking-wider text-zinc-500">
+        トピック
+      </h2>
+      <div className="grid grid-cols-2 gap-3">
+        {topics.map((topic) => (
+          <Link
+            key={topic.id}
+            href={`/topics/${topic.id}`}
+            className="flex items-center gap-2.5 rounded-xl bg-zinc-800/60 p-3.5 transition-colors hover:bg-zinc-700/80 active:bg-zinc-700"
+          >
+            {/* 絵文字アイコン */}
+            {topic.emoji && (
+              <span className="text-2xl leading-none flex-shrink-0" aria-hidden="true">
+                {topic.emoji}
+              </span>
+            )}
+            {/* タイトル */}
+            <span className="truncate text-sm font-medium text-zinc-100">
+              {topic.title}
+            </span>
+          </Link>
+        ))}
+      </div>
+    </section>
+  );
+};
+
+export default TopicList;

--- a/src/components/profile/UserInfo.tsx
+++ b/src/components/profile/UserInfo.tsx
@@ -1,0 +1,39 @@
+import { type User } from "@/types/user";
+import Avatar from "@/components/ui/Avatar";
+import Badge from "@/components/ui/Badge";
+
+type UserInfoProps = {
+  user: User;
+  topicCount: number;
+  activityCount: number;
+};
+
+const UserInfo = ({ user, topicCount, activityCount }: UserInfoProps) => {
+  return (
+    <div className="flex flex-col items-center gap-3 px-4 py-8">
+      {/* アバター */}
+      <Avatar src={user.avatarUrl} alt={user.name} size="lg" className="ring-2 ring-violet-500/60" />
+
+      {/* 名前 + バッジ */}
+      <div className="flex items-center gap-2">
+        <span className="text-xl font-bold text-zinc-100">{user.name}</span>
+        {user.badge && <Badge emoji={user.badge} />}
+      </div>
+
+      {/* 統計 */}
+      <div className="flex items-center gap-6 text-sm text-zinc-400">
+        <div className="flex flex-col items-center gap-0.5">
+          <span className="text-lg font-semibold text-zinc-100">{topicCount}</span>
+          <span>トピック</span>
+        </div>
+        <div className="w-px h-8 bg-zinc-700" />
+        <div className="flex flex-col items-center gap-0.5">
+          <span className="text-lg font-semibold text-zinc-100">{activityCount}</span>
+          <span>アクティビティ</span>
+        </div>
+      </div>
+    </div>
+  );
+};
+
+export default UserInfo;

--- a/src/mocks/activities.ts
+++ b/src/mocks/activities.ts
@@ -682,7 +682,65 @@ const topic4_3Activities: Activity[] = [
   },
 ];
 
+// ─── user-1 の 2025 年分の履歴アクティビティ（カレンダー映え用）───────────
+const topic1_historicalActivities: Activity[] = [
+  // 2025年4月
+  { id: "act-h-1", topicId: "topic-1-1", userId: "user-1", body: "『火花』を読了。芸人の世界がこれほど繊細に描かれているとは思わなかった。", createdAt: "2025-04-07T21:00:00+09:00" },
+  { id: "act-h-2", topicId: "topic-1-4", userId: "user-1", body: "花見。近所の公園の桜がちょうど満開だった。来年もこの景色を見たい。", imageUrls: ["https://picsum.photos/seed/hanami/600/400"], createdAt: "2025-04-05T16:30:00+09:00" },
+  { id: "act-h-3", topicId: "topic-1-3", userId: "user-1", body: "春菊のごま和え。シンプルだけど旬の野菜はやっぱり美味しい。", createdAt: "2025-04-12T19:00:00+09:00" },
+  { id: "act-h-4", topicId: "topic-1-2", userId: "user-1", body: "『PERFECT DAYS』鑑賞。役所広司の演技と東京の光の描写が圧巻。", createdAt: "2025-04-20T22:30:00+09:00" },
+  { id: "act-h-5", topicId: "topic-1-4", userId: "user-1", body: "新年度スタート。今年度は気になったことをこまめに書き留めるようにしたい。", createdAt: "2025-04-01T23:00:00+09:00" },
+  // 2025年5月
+  { id: "act-h-6", topicId: "topic-1-1", userId: "user-1", body: "『ノルウェイの森』再読。10年ぶりに読むと主人公よりも登場人物の脇役が気になった。", createdAt: "2025-05-03T22:00:00+09:00" },
+  { id: "act-h-7", topicId: "topic-1-3", userId: "user-1", body: "筍ご飯。旬の時期にしか作れない一品。土鍋で炊くと香りが違う。", imageUrls: ["https://picsum.photos/seed/takenoko/600/400"], createdAt: "2025-05-10T19:30:00+09:00" },
+  { id: "act-h-8", topicId: "topic-1-4", userId: "user-1", body: "GW中に家族でキャンプへ。夜の星空が圧倒的だった。スマホを置いて過ごす時間の贅沢。", createdAt: "2025-05-04T20:00:00+09:00" },
+  { id: "act-h-9", topicId: "topic-1-2", userId: "user-1", body: "『インサイド・ヘッド2』公開！子供たちが大喜び。大人も感情移入できる良作。", createdAt: "2025-05-18T21:00:00+09:00" },
+  { id: "act-h-10", topicId: "topic-1-1", userId: "user-1", body: "『82年生まれ、キム・ジヨン』読了。疑似体験として読むことの意味を改めて感じた。", createdAt: "2025-05-25T23:00:00+09:00" },
+  // 2025年6月
+  { id: "act-h-11", topicId: "topic-1-3", userId: "user-1", body: "梅雨入り。蒸し暑い日には冷やし中華が正解。具材を多めに準備すると映える。", createdAt: "2025-06-08T18:30:00+09:00" },
+  { id: "act-h-12", topicId: "topic-1-4", userId: "user-1", body: "友人の結婚式。スピーチを頼まれた。緊張したけど無事に伝えられた気がする。", createdAt: "2025-06-14T23:30:00+09:00" },
+  { id: "act-h-13", topicId: "topic-1-2", userId: "user-1", body: "『哀れなるものたち』を再鑑賞。2回目の方がキャラクターの背景が見えてより深く楽しめた。", createdAt: "2025-06-22T22:00:00+09:00" },
+  { id: "act-h-14", topicId: "topic-1-1", userId: "user-1", body: "梅雨の読書週間。今月は短編集をいくつか読んだ。星野道夫の写真エッセイが特に良かった。", createdAt: "2025-06-28T21:30:00+09:00" },
+  // 2025年7月
+  { id: "act-h-15", topicId: "topic-1-4", userId: "user-1", body: "海水浴。海はやっぱり夏に限る。子供が初めて波に乗れた。", imageUrls: ["https://picsum.photos/seed/beach/600/400"], createdAt: "2025-07-20T17:00:00+09:00" },
+  { id: "act-h-16", topicId: "topic-1-3", userId: "user-1", body: "夏野菜カレー。トマト・なす・ズッキーニで作った夏限定レシピ。彩りが鮮やかで食欲が増す。", imageUrls: ["https://picsum.photos/seed/summercurry/600/400"], createdAt: "2025-07-06T19:30:00+09:00" },
+  { id: "act-h-17", topicId: "topic-1-1", userId: "user-1", body: "『夏への扉』を読んだ。SFの古典だけど今でも全然色褪せていない。ハインラインの着想力に感服。", createdAt: "2025-07-14T22:00:00+09:00" },
+  { id: "act-h-18", topicId: "topic-1-4", userId: "user-1", body: "花火大会。久しぶりに浴衣を着た。混雑しすぎていたけど、それも夏の思い出。", createdAt: "2025-07-26T23:00:00+09:00" },
+  // 2025年8月
+  { id: "act-h-19", topicId: "topic-1-2", userId: "user-1", body: "お盆休みに映画館で3本ハシゴ。夏は映画の季節。ポップコーン食べすぎた。", createdAt: "2025-08-14T21:30:00+09:00" },
+  { id: "act-h-20", topicId: "topic-1-3", userId: "user-1", body: "スイカゼリーを作った。見た目が涼やかで子供に大好評。夏の定番デザートになりそう。", imageUrls: ["https://picsum.photos/seed/watermelongelatin/600/400"], createdAt: "2025-08-03T16:00:00+09:00" },
+  { id: "act-h-21", topicId: "topic-1-4", userId: "user-1", body: "帰省。実家でのんびり過ごした。久しぶりに親の料理を食べると落ち着く。", createdAt: "2025-08-11T20:30:00+09:00" },
+  { id: "act-h-22", topicId: "topic-1-1", userId: "user-1", body: "積読してた『人類の星の時間』をやっと読了。短編集なのにそれぞれのスケールが大きい。", createdAt: "2025-08-24T23:00:00+09:00" },
+  { id: "act-h-23", topicId: "topic-1-4", userId: "user-1", body: "セミの声が少なくなってきた。夏の終わりを感じる。つい最近夏が始まった気がするのに。", createdAt: "2025-08-28T19:00:00+09:00" },
+  // 2025年9月
+  { id: "act-h-24", topicId: "topic-1-3", userId: "user-1", body: "栗ご飯。秋の訪れを感じるメニュー。栗をむく作業が大変だったが、食べると報われた。", imageUrls: ["https://picsum.photos/seed/chestnutrice/600/400"], createdAt: "2025-09-07T19:30:00+09:00" },
+  { id: "act-h-25", topicId: "topic-1-2", userId: "user-1", body: "映画館がすいてきた平日に『関心領域』を観た。これほど静かに恐怖を描いた映画は初めて。", createdAt: "2025-09-13T22:30:00+09:00" },
+  { id: "act-h-26", topicId: "topic-1-1", userId: "user-1", body: "読書の秋。今月は月5冊ペースで読む目標を立てた。まずは積読から消化。", createdAt: "2025-09-01T21:00:00+09:00" },
+  { id: "act-h-27", topicId: "topic-1-4", userId: "user-1", body: "彼岸花が咲いていた。毎年この時期になると必ず咲いているのが不思議で感慨深い。", createdAt: "2025-09-22T17:00:00+09:00" },
+  { id: "act-h-28", topicId: "topic-1-1", userId: "user-1", body: "『人間失格』を初めて読んだ。中学生の時に読まなくて良かったかもしれない。", createdAt: "2025-09-18T23:00:00+09:00" },
+  // 2025年10月
+  { id: "act-h-29", topicId: "topic-1-3", userId: "user-1", body: "さつまいもの炊き込みご飯。ほくほくの甘みが秋らしい。子供が「また作って」と言った。", createdAt: "2025-10-11T19:00:00+09:00" },
+  { id: "act-h-30", topicId: "topic-1-4", userId: "user-1", body: "旅行どころに紅葉狩りへ。今年は色づきが遅かったが、想像以上に绮麗だった。", imageUrls: ["https://picsum.photos/seed/koyo/600/400"], createdAt: "2025-10-19T16:30:00+09:00" },
+  { id: "act-h-31", topicId: "topic-1-2", userId: "user-1", body: "秋の映画祭でフランス映画特集。字幕を追うのが大変だったが2本完走。新しい監督を発見。", createdAt: "2025-10-05T21:30:00+09:00" },
+  { id: "act-h-32", topicId: "topic-1-1", userId: "user-1", body: "松尾芭蕉の俳句集を購入。秋に読む俳句は特別な味わいがある。", createdAt: "2025-10-26T22:00:00+09:00" },
+  { id: "act-h-33", topicId: "topic-1-4", userId: "user-1", body: "ハロウィンで子供たちといくつかの家を廻った。仮装のクオリティが年々上がっている気がする。", createdAt: "2025-10-31T21:00:00+09:00" },
+  // 2025年11月
+  { id: "act-h-34", topicId: "topic-1-1", userId: "user-1", body: "『存在と時間』に再挑戦。ハイデガーは難しいが少しずつ自分の言葉に落とせてきた気がする。", createdAt: "2025-11-08T23:00:00+09:00" },
+  { id: "act-h-35", topicId: "topic-1-3", userId: "user-1", body: "おでん解禁！大根・はんぺん・卵・こんにゃく・牛筋を朝から煮込む。夜には完璧な味に。", imageUrls: ["https://picsum.photos/seed/oden/600/400"], createdAt: "2025-11-02T20:00:00+09:00" },
+  { id: "act-h-36", topicId: "topic-1-4", userId: "user-1", body: "クリスマスに向けてイルミネーション巡りを計画中。今年はどこへ行こうか。", createdAt: "2025-11-15T21:00:00+09:00" },
+  { id: "act-h-37", topicId: "topic-1-2", userId: "user-1", body: "初めてMCUの映画を一気見した。世界観の広さに圧倒される。脱落しながらも楽しんだ。", createdAt: "2025-11-22T23:30:00+09:00" },
+  { id: "act-h-38", topicId: "topic-1-1", userId: "user-1", body: "今年読んだ本を振り返ってみた。思いのほか量が少なくて来年は目標を上げようと決意。", createdAt: "2025-11-30T22:00:00+09:00" },
+  // 2025年12月
+  { id: "act-h-39", topicId: "topic-1-3", userId: "user-1", body: "年末は恒例のローストチキン。今年は塩麹を使ってみたがジューシーさが段違いだった。", imageUrls: ["https://picsum.photos/seed/roastchicken/600/400"], createdAt: "2025-12-25T20:00:00+09:00" },
+  { id: "act-h-40", topicId: "topic-1-4", userId: "user-1", body: "大掃除完了。家の隅々まできれいにすると気持ちがリセットされる感覚がある。", createdAt: "2025-12-30T17:00:00+09:00" },
+  { id: "act-h-41", topicId: "topic-1-1", userId: "user-1", body: "正月用に古典を一冊購入。年始はゆっくり読書で過ごしたい。", createdAt: "2025-12-28T21:00:00+09:00" },
+  { id: "act-h-42", topicId: "topic-1-2", userId: "user-1", body: "今年の映画ベスト10を作った。邦画の充実ぶりが印象的な一年だった。", createdAt: "2025-12-15T22:30:00+09:00" },
+  { id: "act-h-43", topicId: "topic-1-4", userId: "user-1", body: "忘年会シーズン。久しぶりに会う友人たちと年末の雰囲気で盛り上がった。", createdAt: "2025-12-07T23:30:00+09:00" },
+  { id: "act-h-44", topicId: "topic-1-3", userId: "user-1", body: "年末の鍋パーティ。水炊きに柚子胡椒が合う。〆の雑炊まで完食。", createdAt: "2025-12-21T21:00:00+09:00" },
+];
+
 export const activities: Activity[] = [
+  ...topic1_historicalActivities,
   ...topic1_1Activities,
   ...topic1_2Activities,
   ...topic1_3Activities,


### PR DESCRIPTION
## 概要

Issue #7 に対応し、プロフィール画面 (`/profile`) を実装しました。
振り返りタイル（GitHub 風カレンダー）により「継続して書き留めることの楽しさ・自分の活動が可視化される記録としての価値」をプレゼンで伝えやすい画面になっています。

## 変更ファイル一覧

| ファイル | 種別 | 内容 |
|---|---|---|
| `src/app/profile/page.tsx` | 新規 | プロフィールページ本体（Server Component） |
| `src/components/profile/UserInfo.tsx` | 新規 | アイコン・名前・バッジ・統計（トピック数/アクティビティ数）表示 |
| `src/components/profile/TopicList.tsx` | 新規 | 自分のトピック一覧グリッド（タップでトピック詳細へ遷移） |
| `src/components/profile/ActivityTileCalendar.tsx` | 新規 | 振り返りタイル（GitHub 風カレンダー） |
| `src/mocks/activities.ts` | 変更 | user-1 の 2025 年 4〜12 月分の履歴アクティビティ 44 件を追加（カレンダーを映えさせるため） |

## 実装内容

- [x] ユーザー情報（アイコン・名前・バッジ・トピック数・アクティビティ数）の表示
- [x] 自分のトピック一覧を 2 列グリッドで表示（タップでトピック詳細へ遷移）
- [x] 振り返りタイル
  - 過去 52 週分（1 年）の日次セルを GitHub 風グリッドで表示（7 行 × 52 列）
  - 日別の投稿数に応じて 5 段階で色を変える（`bg-zinc-800` → `bg-green-200` → `bg-green-400` → `bg-green-500` → `bg-green-700`）
  - 週カラムをクリックすると、その週のアクティビティ一覧を画面下部に展開表示（再クリックで閉じる）
  - カレンダー基準日を `2026-04-01` に固定し、モックデータと一致させた
  - 「少/多」凡例を右下に表示
  - 横スクロール対応（`overflow-x-auto`）

## 設計上の決定

| 決定事項 | 内容 |
|---|---|
| 日次 vs 週次 | 仕様書にある「日々の投稿数を可視化」に従い日次セルで表現。クリック時は週単位でアクティビティを表示 |
| REFERENCE_DATE 固定 | モックデータが 2025/04〜2026/03 に集中しているため `new Date("2026-04-01")` をハードコード |
| 履歴データ追加 | カレンダーのビジュアルインパクトを出すため、2025 年分の user-1 アクティビティ 44 件を追加 |

## 依存 Issue

- #3 モックデータ（完了済み）
- #4 共通 UI コンポーネント（完了済み）

## テスト確認

- `npm run build` でエラーなし（TypeScript 型チェック含む）
- `/profile` で画面が正常に表示されることを確認
- 振り返りタイルの週クリック → アクティビティ展開 → 再クリックで閉じる動作を確認
- トピックグリッドのタップ → `/topics/[topicId]` への遷移を確認
- コーディング規約（`style` 属性なし・`any` 型なし・アロー関数・`type` 優先）の遵守を確認
