### PR TITLE
feat: 検索画面を実装する (#10)

### DIFF
--- a/src/app/search/page.tsx
+++ b/src/app/search/page.tsx
@@ -1,0 +1,71 @@
+"use client";
+
+import { useState, useMemo } from "react";
+import { activities } from "@/mocks/activities";
+import { topics } from "@/mocks/topics";
+import { users, currentUser } from "@/mocks/users";
+import { subscribedTopicIds } from "@/mocks/subscriptions";
+import SearchBar from "@/components/search/SearchBar";
+import SearchScopeSelector, {
+  type SearchScope,
+} from "@/components/search/SearchScopeSelector";
+import SearchResults from "@/components/search/SearchResults";
+
+// O(1) 参照用マップ
+const topicMap = new Map(topics.map((t) => [t.id, t]));
+const userMap = new Map(users.map((u) => [u.id, u]));
+
+export default function SearchPage() {
+  const [query, setQuery] = useState("");
+  const [scope, setScope] = useState<SearchScope>("all");
+
+  const results = useMemo(() => {
+    const trimmed = query.trim();
+    if (!trimmed) return [];
+
+    const lowerQuery = trimmed.toLowerCase();
+
+    // ① スコープでフィルタ
+    const scopedActivities = activities.filter((a) => {
+      if (scope === "mine") return a.userId === currentUser.id;
+      if (scope === "subscribed") return subscribedTopicIds.includes(a.topicId);
+      return true; // "all"
+    });
+
+    // ② クエリで部分一致フィルタ（本文を対象）
+    const matched = scopedActivities.filter((a) =>
+      a.body.toLowerCase().includes(lowerQuery),
+    );
+
+    // ③ 新しい順にソート
+    matched.sort(
+      (a, b) =>
+        new Date(b.createdAt).getTime() - new Date(a.createdAt).getTime(),
+    );
+
+    // ④ user / topic を解決して返す
+    return matched.flatMap((activity) => {
+      const user = userMap.get(activity.userId);
+      const topic = topicMap.get(activity.topicId);
+      if (!user || !topic) return [];
+      return [{ activity, user, topic }];
+    });
+  }, [query, scope]);
+
+  return (
+    <div className="flex flex-col">
+      {/* スティッキーヘッダー */}
+      <header className="sticky top-0 z-10 border-b border-zinc-800 bg-zinc-950/80 px-4 py-3 backdrop-blur-sm">
+        <h1 className="mb-3 text-lg font-bold text-zinc-100">検索</h1>
+        <div className="flex flex-col gap-2">
+          <SearchBar value={query} onChange={setQuery} />
+          <SearchScopeSelector scope={scope} onScopeChange={setScope} />
+        </div>
+      </header>
+
+      <main className="px-4 py-4">
+        <SearchResults query={query.trim()} results={results} />
+      </main>
+    </div>
+  );
+}

--- a/src/components/search/SearchBar.tsx
+++ b/src/components/search/SearchBar.tsx
@@ -1,0 +1,27 @@
+type SearchBarProps = {
+  value: string;
+  onChange: (value: string) => void;
+};
+
+/**
+ * キーワード入力フィールド。
+ * 入力のたびに onChange を呼び出し、親コンポーネントが状態を管理する。
+ */
+const SearchBar = ({ value, onChange }: SearchBarProps) => {
+  return (
+    <div className="relative">
+      <span className="pointer-events-none absolute inset-y-0 left-3 flex items-center text-zinc-500">
+        🔍
+      </span>
+      <input
+        type="search"
+        value={value}
+        onChange={(e) => onChange(e.target.value)}
+        placeholder="キーワードで検索..."
+        className="w-full rounded-xl border border-zinc-700 bg-zinc-800 py-2.5 pl-9 pr-4 text-sm text-zinc-100 placeholder:text-zinc-500 focus:border-violet-500 focus:outline-none focus:ring-1 focus:ring-violet-500"
+      />
+    </div>
+  );
+};
+
+export default SearchBar;

--- a/src/components/search/SearchResults.tsx
+++ b/src/components/search/SearchResults.tsx
@@ -1,0 +1,77 @@
+import { type Activity } from "@/types/activity";
+import { type User } from "@/types/user";
+import { type Topic } from "@/types/topic";
+import ActivityCard from "@/components/ui/ActivityCard";
+
+type SearchResultItem = {
+  activity: Activity;
+  user: User;
+  topic: Topic;
+};
+
+type SearchResultsProps = {
+  query: string;
+  results: SearchResultItem[];
+};
+
+/**
+ * 検索結果一覧。
+ * - クエリ未入力: 検索促進メッセージを表示
+ * - クエリあり・0件: 該当なしメッセージを表示
+ * - クエリあり・N件: ヒット件数 + ActivityCard の一覧を表示
+ */
+const SearchResults = ({ query, results }: SearchResultsProps) => {
+  if (!query) {
+    return (
+      <div className="flex flex-col items-center gap-3 py-20 text-center">
+        <p className="text-3xl">🔍</p>
+        <p className="text-sm text-zinc-400">
+          キーワードを入力して検索してください
+        </p>
+        <p className="text-xs text-zinc-600">
+          アクティビティの本文をスコープに応じて絞り込みます
+        </p>
+      </div>
+    );
+  }
+
+  if (results.length === 0) {
+    return (
+      <div className="flex flex-col items-center gap-3 py-20 text-center">
+        <p className="text-3xl">😶</p>
+        <p className="text-sm text-zinc-400">
+          「{query}」に一致するアクティビティが見つかりませんでした
+        </p>
+        <p className="text-xs text-zinc-600">
+          別のキーワードやスコープで試してみてください
+        </p>
+      </div>
+    );
+  }
+
+  return (
+    <div className="flex flex-col gap-3">
+      {/* ヒット件数 */}
+      <p className="text-xs text-zinc-500">
+        <span className="font-semibold text-violet-400">{results.length}</span>
+        &nbsp;件ヒット
+      </p>
+
+      {/* 結果一覧 */}
+      <ul className="flex flex-col gap-3">
+        {results.map(({ activity, user, topic }) => (
+          <li key={activity.id}>
+            <ActivityCard
+              activity={activity}
+              user={user}
+              topicTitle={`${topic.emoji ?? ""} ${topic.title}`.trim()}
+              topicId={topic.id}
+            />
+          </li>
+        ))}
+      </ul>
+    </div>
+  );
+};
+
+export default SearchResults;

--- a/src/components/search/SearchScopeSelector.tsx
+++ b/src/components/search/SearchScopeSelector.tsx
@@ -1,0 +1,49 @@
+import { cn } from "@/lib/utils";
+
+export type SearchScope = "all" | "mine" | "subscribed";
+
+type ScopeOption = {
+  value: SearchScope;
+  label: string;
+};
+
+const SCOPE_OPTIONS: ScopeOption[] = [
+  { value: "all", label: "全体" },
+  { value: "mine", label: "自分" },
+  { value: "subscribed", label: "サブスク" },
+];
+
+type SearchScopeSelectorProps = {
+  scope: SearchScope;
+  onScopeChange: (scope: SearchScope) => void;
+};
+
+/**
+ * 検索スコープ切り替えタブ。
+ * 「全体 / 自分 / サブスク」の 3 種類から選択する。
+ */
+const SearchScopeSelector = ({
+  scope,
+  onScopeChange,
+}: SearchScopeSelectorProps) => {
+  return (
+    <div className="flex gap-1 rounded-lg bg-zinc-800/60 p-1">
+      {SCOPE_OPTIONS.map((option) => (
+        <button
+          key={option.value}
+          onClick={() => onScopeChange(option.value)}
+          className={cn(
+            "flex-1 rounded-md py-1.5 text-xs font-medium transition-colors",
+            scope === option.value
+              ? "bg-violet-600 text-white shadow-sm"
+              : "text-zinc-400 hover:text-zinc-200",
+          )}
+        >
+          {option.label}
+        </button>
+      ))}
+    </div>
+  );
+};
+
+export default SearchScopeSelector;


### PR DESCRIPTION
## 概要

Issue #10「検索画面を実装する」の対応。

キーワードと検索スコープ（全体 / 自分 / サブスク）を組み合わせて、モックデータのアクティビティを絞り込む `/search` 画面を追加した。

## 変更ファイル

| ファイル | 変更内容 |
|---|---|
| `src/app/search/page.tsx` | 検索画面ページを新規追加 |
| `src/components/search/SearchBar.tsx` | テキスト入力コンポーネントを新規追加 |
| `src/components/search/SearchScopeSelector.tsx` | スコープ切り替え UI を新規追加 |
| `src/components/search/SearchResults.tsx` | 検索結果一覧コンポーネントを新規追加 |

## 実装内容

### ページ (`src/app/search/page.tsx`)

- `"use client"` ページとして `query`（検索文字列）と `scope`（検索スコープ）を `useState` で管理
- `useMemo` で query / scope が変わるたびに再計算（余分な再レンダリングを抑制）
- スコープ → クエリの順で `Array.filter()` + `String.includes()` で絞り込み、`createdAt` 降順ソート
- スティッキーヘッダーに SearchBar + SearchScopeSelector を配置

### SearchBar (`src/components/search/SearchBar.tsx`)

- `value` / `onChange` を受け取る制御コンポーネント
- `type="search"` で入力クリアボタンをブラウザネイティブに表示
- `"use client"` 不使用（クライアントページから呼ばれるため不要）

### SearchScopeSelector (`src/components/search/SearchScopeSelector.tsx`)

- `"全体" / "自分" / "サブスク"` の 3 タブ UI
- アクティブタブは `bg-violet-600` でハイライト（アプリ全体のテーマカラーに統一）
- `SearchScope` 型（`"all" | "mine" | "subscribed"`）を named export し、page.tsx と共有
- `"use client"` 不使用（クライアントページから呼ばれるため不要）

### SearchResults (`src/components/search/SearchResults.tsx`)

- 3 状態を出し分け:
  - クエリ未入力 → 検索促進メッセージ
  - クエリあり・0件 → 該当なしメッセージ
  - クエリあり・N件 → ヒット件数 + ActivityCard 一覧（`ui/ActivityCard` を再利用）
- `"use client"` 不使用（副作用なし・Server Component）

### スコープ仕様

| スコープ | 対象 |
|---|---|
| 全体 | すべてのユーザーのアクティビティ |
| 自分 | `currentUser`（山田 太郎）のアクティビティのみ |
| サブスク | `subscribedTopicIds` に含まれるトピックのアクティビティのみ |

## AC確認

- [x] テキスト入力欄（SearchBar）の実装
- [x] 検索スコープの切り替え UI（全体 / 自分のみ / サブスク中）
- [x] 入力に応じてモックデータから部分一致絞り込み（`String.includes()`）
- [x] ヒット件数・結果一覧の表示

## 依存 Issue

- #3 モックデータ（完了済み）
- #4 共通 UI コンポーネント（完了済み）
