### PR TITLE
feat: 【仕上げ】見栄えの調整・プレゼン前の最終確認 (#11)

### DIFF
--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -21,7 +21,7 @@ export default function RootLayout({
   return (
     <html
       lang="ja"
-      className={`${geistSans.variable} h-full antialiased dark`}
+      className={`${geistSans.variable} h-full antialiased dark scroll-smooth`}
     >
       <body className="min-h-full bg-zinc-950 text-zinc-100">
         {/* スマホ幅に固定してモバイルアプリらしいレイアウトに */}

--- a/src/components/home/ActivityCard.tsx
+++ b/src/components/home/ActivityCard.tsx
@@ -14,11 +14,12 @@ type Props = {
  * ui/ActivityCard にトピック情報を解決して渡すラッパー。
  */
 const ActivityCard = ({ activity, topic, user }: Props) => {
+  const topicTitle = [topic.emoji, topic.title].filter(Boolean).join(" ");
   return (
     <UIActivityCard
       activity={activity}
       user={user}
-      topicTitle={topic.title}
+      topicTitle={topicTitle}
       topicId={topic.id}
     />
   );

--- a/src/components/topic/TopicActivityFeed.tsx
+++ b/src/components/topic/TopicActivityFeed.tsx
@@ -21,6 +21,7 @@ const TopicActivityFeed = ({ topic }: TopicActivityFeedProps) => {
 
   // ユーザーを O(1) で引けるようにマップ化
   const userMap = new Map(users.map((u) => [u.id, u]));
+  const topicTitle = [topic.emoji, topic.title].filter(Boolean).join(" ");
 
   if (topicActivities.length === 0) {
     return (
@@ -40,7 +41,7 @@ const TopicActivityFeed = ({ topic }: TopicActivityFeedProps) => {
             <UIActivityCard
               activity={activity}
               user={user}
-              topicTitle={topic.title}
+              topicTitle={topicTitle}
               topicId={topic.id}
             />
           </li>

--- a/src/components/ui/ActivityCard.tsx
+++ b/src/components/ui/ActivityCard.tsx
@@ -61,7 +61,7 @@ const ActivityCard = ({
   return (
     <article
       className={cn(
-        "flex flex-col gap-3 rounded-2xl bg-zinc-800/60 p-4 transition-colors hover:bg-zinc-800",
+        "flex flex-col gap-3 rounded-2xl bg-zinc-800/60 p-4 transition hover:bg-zinc-800 hover:scale-[1.01] active:scale-[0.99]",
         className,
       )}
     >


### PR DESCRIPTION
## 概要

Issue #11「【仕上げ】見栄えの調整・プレゼン前の最終確認」の対応。

各画面の実装完了後、プレゼンの印象を高めるためのスタイル調整・細部仕上げを行った。

## 変更ファイル

| ファイル | 変更内容 |
|---|---|
| `src/app/layout.tsx` | `scroll-smooth` を追加しスクロールを滑らかに |
| `src/components/ui/ActivityCard.tsx` | hover に `scale` エフェクトを追加して動的な印象を強化 |
| `src/components/home/ActivityCard.tsx` | `topicTitle` に絵文字を結合して TopicChip に表示 |
| `src/components/topic/TopicActivityFeed.tsx` | `topicTitle` に絵文字を結合して TopicChip に表示 |

## 実装内容

### レイアウト・スタイル

**スマホ幅への統一 (既実装済み)**
- `layout.tsx` の `max-w-sm mx-auto` により縦長モバイルアプリらしいレイアウトは完成済み。

**テーマカラー統一 (既実装済み)**
- `violet` をテーマカラーとして全画面に統一適用済み（BottomNav アクティブ: `text-violet-400`、サブスクボタン: `bg-violet-600`、検索スコープセレクタ: `bg-violet-600` など）。

**トピック絵文字の表示**
- `home/ActivityCard.tsx` と `TopicActivityFeed.tsx` で `topicTitle` を `"${emoji} ${title}"` 形式に統一。
- `SubscriptionFeed.tsx` / `SearchResults.tsx` は既に対応済みだったため変更なし。
- これにより全画面の ActivityCard トピックチップに絵文字が表示される。

**スクロール改善**
- `html` 要素に `scroll-smooth` を追加してプレゼン中のスクロールを自然な動きに。

### インタラクション

**ActivityCard の hover エフェクト強化**
- `transition-colors hover:bg-zinc-800` → `transition hover:bg-zinc-800 hover:scale-[1.01] active:scale-[0.99]` に変更。
- 背景色変化に加えて微細な拡大・縮小アニメーションが加わり、タップ感のあるインタラクションになった。

**BottomNav アクティブハイライト (既実装済み)**
- 現在のパスに一致するタブが `text-violet-400` でハイライトされる実装は完成済み。

## AC確認

- [x] 全体をスマホ幅（`max-w-sm mx-auto`）に収め、縦長モバイルアプリらしい見た目にする
- [x] テーマカラーを 1 色（`violet`）に決めて統一感を出す
- [x] トピックのアイコンに絵文字を使い、一覧の見栄えをよくする
- [x] ActivityCard に `hover:` / `transition` を付けて動的な印象を与える
- [x] BottomNav のアクティブタブをハイライト表示
- [x] スクロールが自然に動くか確認（`scroll-smooth` 追加）
- [x] 画面遷移がスムーズか確認（Next.js App Router の Link コンポーネントで対応済み）

## ベースブランチについて

`feature/issue-10-search` ベース（issue #10 が main にマージされ次第、base を `main` に変更してください）。

## 依存 Issue

- #5 ホーム画面（完了済み）
- #6 トピック詳細（完了済み）
- #7 プロフィール（完了済み）
- #8 サブスク（完了済み）
- #10 検索画面（完了済み・未マージ）
