### PR TITLE
feat: BottomNavの絵文字アイコンをLucide React SVGアイコンに置き換える (#22)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9,6 +9,7 @@
       "version": "0.1.0",
       "dependencies": {
         "clsx": "^2.1.1",
+        "lucide-react": "^1.7.0",
         "next": "16.2.2",
         "react": "19.2.4",
         "react-dom": "19.2.4",
@@ -4878,6 +4879,15 @@
       "license": "ISC",
       "dependencies": {
         "yallist": "^3.0.2"
+      }
+    },
+    "node_modules/lucide-react": {
+      "version": "1.7.0",
+      "resolved": "https://registry.npmjs.org/lucide-react/-/lucide-react-1.7.0.tgz",
+      "integrity": "sha512-yI7BeItCLZJTXikmK4KNUGCKoGzSvbKlfCvw44bU4fXAL6v3gYS4uHD1jzsLkfwODYwI6Drw5Tu9Z5ulDe0TSg==",
+      "license": "ISC",
+      "peerDependencies": {
+        "react": "^16.5.1 || ^17.0.0 || ^18.0.0 || ^19.0.0"
       }
     },
     "node_modules/magic-string": {

--- a/package.json
+++ b/package.json
@@ -10,6 +10,7 @@
   },
   "dependencies": {
     "clsx": "^2.1.1",
+    "lucide-react": "^1.7.0",
     "next": "16.2.2",
     "react": "19.2.4",
     "react-dom": "19.2.4",

--- a/src/components/ui/BottomNav.tsx
+++ b/src/components/ui/BottomNav.tsx
@@ -2,19 +2,20 @@
 
 import Link from "next/link";
 import { usePathname } from "next/navigation";
+import { Home, Bell, Search, User, type LucideIcon } from "lucide-react";
 import { cn } from "@/lib/utils";
 
 type NavItem = {
   href: string;
   label: string;
-  icon: string;
+  icon: LucideIcon;
 };
 
 const NAV_ITEMS: NavItem[] = [
-  { href: "/", label: "ホーム", icon: "🏠" },
-  { href: "/subscriptions", label: "サブスク", icon: "🔔" },
-  { href: "/search", label: "検索", icon: "🔍" },
-  { href: "/profile", label: "プロフィール", icon: "👤" },
+  { href: "/", label: "ホーム", icon: Home },
+  { href: "/subscriptions", label: "サブスク", icon: Bell },
+  { href: "/search", label: "検索", icon: Search },
+  { href: "/profile", label: "プロフィール", icon: User },
 ];
 
 const BottomNav = () => {
@@ -25,6 +26,7 @@ const BottomNav = () => {
       <ul className="flex w-full max-w-sm items-center">
         {NAV_ITEMS.map((item) => {
           const isActive = pathname === item.href;
+          const Icon = item.icon;
           return (
             <li key={item.href} className="flex-1">
               <Link
@@ -36,7 +38,7 @@ const BottomNav = () => {
                     : "text-zinc-500 hover:text-zinc-300",
                 )}
               >
-                <span className="text-xl leading-none">{item.icon}</span>
+                <Icon size={22} strokeWidth={isActive ? 2.5 : 2} />
                 <span>{item.label}</span>
               </Link>
             </li>


### PR DESCRIPTION
## 概要

BottomNav に使われていた絵文字アイコン（🏠🔔🔍👤）を、Lucide React の SVG アイコンに置き換えました。
絵文字は OS・端末によって見た目が異なるため、SVG アイコンに統一することでデザインの一貫性を確保します。

## 変更内容

- `lucide-react` をインストール
- `BottomNav` の `NavItem` 型を `icon: string` → `icon: LucideIcon` に変更
- 各タブのアイコンを以下のとおり置換：
  - ホーム → `<Home />`
  - サブスク → `<Bell />`
  - 検索 → `<Search />`
  - プロフィール → `<User />`
- アクティブ時に `strokeWidth={2.5}`、非アクティブ時に `strokeWidth={2}` を設定し、視覚的なフィードバックを強化
- アクティブ/非アクティブの配色（`text-violet-400` / `text-zinc-500`）は変更なし

## 変更ファイル

| ファイル | 変更種別 |
|---|---|
| `src/components/ui/BottomNav.tsx` | 修正 |
| `package.json` | 依存追加（lucide-react） |
| `package-lock.json` | 自動更新 |

## テスト

- TypeScript 型チェック（`tsc --noEmit`）: エラーなし
- 各ページのアクティブ/非アクティブスタイルが SVG でも正しく適用されることを目視確認

## Close

Closes #22
