### PR TITLE
feat: BottomNav にアクティブインジケーター（背景ピル）とアニメーションを追加 （#25）

### DIFF
--- a/src/components/ui/BottomNav.tsx
+++ b/src/components/ui/BottomNav.tsx
@@ -32,14 +32,33 @@ const BottomNav = () => {
               <Link
                 href={item.href}
                 className={cn(
-                  "flex flex-col items-center gap-0.5 py-2.5 text-xs font-medium transition-colors",
+                  "flex flex-col items-center py-2 transition-colors duration-200",
                   isActive
                     ? "text-violet-400"
                     : "text-zinc-500 hover:text-zinc-300",
                 )}
               >
-                <Icon size={22} strokeWidth={isActive ? 2.5 : 2} />
-                <span>{item.label}</span>
+                {/* アクティブインジケーター：背景ピル */}
+                <span
+                  className={cn(
+                    "flex flex-col items-center gap-0.5 rounded-xl px-5 py-1.5 text-xs font-medium transition-all duration-200",
+                    isActive
+                      ? "bg-violet-500/20"
+                      : "bg-transparent",
+                  )}
+                >
+                  <Icon
+                    size={22}
+                    strokeWidth={isActive ? 2.5 : 2}
+                    className={cn(
+                      "transition-all duration-200",
+                      isActive && "[&>*]:fill-current",
+                    )}
+                  />
+                  <span className="transition-all duration-200">
+                    {item.label}
+                  </span>
+                </span>
               </Link>
             </li>
           );


### PR DESCRIPTION
## 概要

Issue #25 の対応。BottomNav のアクティブタブに背景ピルスタイルとアニメーションを追加し、ネイティブアプリのような操作感を実現した。

## 変更内容

- **背景ピル**: アクティブタブのアイコン・ラベルを `bg-violet-500/20 rounded-xl` のピル型コンテナで囲む
- **アニメーション**: `transition-all duration-200` をピルコンテナ・アイコン・ラベルに付与し、タブ切り替え時の滑らかなフェードを実現
- **filled アイコン**: `[&>*]:fill-current` で CSS から Lucide SVG のパスをアクティブ時に塗りつぶしスタイルへ切り替え（Issue #22 連携）
- **コントラスト**: active `text-violet-400` + `bg-violet-500/20` / inactive `text-zinc-500` で十分な差を確保

## 変更ファイル

- `src/components/ui/BottomNav.tsx`

## AC 対応チェック

- [x] アクティブタブに背景ピル（rounded pill）スタイルを適用する → `bg-violet-500/20 rounded-xl`
- [x] タブ切り替え時に滑らかなトランジションアニメーションを付ける → `transition-all duration-200`
- [x] アクティブ時に SVG アイコンを塗りつぶし（filled）スタイルに切り替える → `[&>*]:fill-current`
- [x] 非アクティブタブとのコントラスト差が十分あることを確認する → violet-400 vs zinc-500

## スクリーンショット

> 動作確認: `npm run dev` 後、各タブを切り替えてピルの out/in とアイコンの filled 切り替えを確認

## 関連 Issue

closes #25
