### PR TITLE
feat: PC対応レスポンシブレイアウトを実装する (#29)

### DIFF
--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -2,6 +2,7 @@ import type { Metadata } from "next";
 import { Geist } from "next/font/google";
 import "./globals.css";
 import BottomNav from "@/components/ui/BottomNav";
+import SideNav from "@/components/ui/SideNav";
 
 const geistSans = Geist({
   variable: "--font-geist-sans",
@@ -24,9 +25,12 @@ export default function RootLayout({
       className={`${geistSans.variable} h-full antialiased dark scroll-smooth`}
     >
       <body className="min-h-full bg-zinc-950 text-zinc-100">
-        {/* スマホ幅に固定してモバイルアプリらしいレイアウトに */}
-        <div className="mx-auto max-w-sm min-h-screen pb-16">
-          {children}
+        {/* PC: SideNav + メインコンテンツの2カラム、モバイル: max-w-sm 中央寄せ */}
+        <div className="mx-auto max-w-sm md:max-w-4xl flex min-h-screen">
+          <SideNav />
+          <main className="flex-1 min-w-0 pb-16 md:pb-0 md:border-x md:border-zinc-800">
+            {children}
+          </main>
         </div>
         <BottomNav />
       </body>

--- a/src/components/ui/BottomNav.tsx
+++ b/src/components/ui/BottomNav.tsx
@@ -22,7 +22,7 @@ const BottomNav = () => {
   const pathname = usePathname();
 
   return (
-    <nav className="fixed bottom-0 left-0 right-0 z-50 flex justify-center border-t border-zinc-700/60 bg-zinc-900/95 backdrop-blur-sm">
+    <nav className="md:hidden fixed bottom-0 left-0 right-0 z-50 flex justify-center border-t border-zinc-700/60 bg-zinc-900/95 backdrop-blur-sm">
       <ul className="flex w-full max-w-sm items-center">
         {NAV_ITEMS.map((item) => {
           const isActive = pathname === item.href;

--- a/src/components/ui/FAB.tsx
+++ b/src/components/ui/FAB.tsx
@@ -21,7 +21,7 @@ const FAB = ({ defaultTopicId }: Props) => {
         type="button"
         onClick={handleOpen}
         aria-label="投稿する"
-        className="fixed bottom-24 right-4 z-40 flex h-14 w-14 items-center justify-center rounded-full bg-violet-600 text-white shadow-lg shadow-violet-900/50 transition-all duration-200 hover:bg-violet-500 active:scale-95 active:bg-violet-700"
+        className="md:hidden fixed bottom-24 right-4 z-40 flex h-14 w-14 items-center justify-center rounded-full bg-violet-600 text-white shadow-lg shadow-violet-900/50 transition-all duration-200 hover:bg-violet-500 active:scale-95 active:bg-violet-700"
       >
         <Pencil size={22} strokeWidth={2.5} />
       </button>

--- a/src/components/ui/SideNav.tsx
+++ b/src/components/ui/SideNav.tsx
@@ -1,0 +1,96 @@
+"use client";
+
+import { useState } from "react";
+import Link from "next/link";
+import { usePathname } from "next/navigation";
+import {
+  Home,
+  Bell,
+  Search,
+  User,
+  Pencil,
+  type LucideIcon,
+} from "lucide-react";
+import { cn } from "@/lib/utils";
+import PostModal from "@/components/ui/PostModal";
+
+type NavItem = {
+  href: string;
+  label: string;
+  icon: LucideIcon;
+};
+
+const NAV_ITEMS: NavItem[] = [
+  { href: "/", label: "ホーム", icon: Home },
+  { href: "/subscriptions", label: "サブスク", icon: Bell },
+  { href: "/search", label: "検索", icon: Search },
+  { href: "/profile", label: "プロフィール", icon: User },
+];
+
+const SideNav = () => {
+  const pathname = usePathname();
+  const [isModalOpen, setIsModalOpen] = useState(false);
+
+  const handleOpenModal = () => setIsModalOpen(true);
+  const handleCloseModal = () => setIsModalOpen(false);
+
+  return (
+    <>
+      <nav className="hidden md:flex flex-col gap-2 w-56 shrink-0 sticky top-0 h-screen pt-6 pb-6 px-3">
+        {/* ロゴ・アプリ名 */}
+        <div className="px-3 pb-4">
+          <span className="text-xl font-bold text-violet-400 tracking-tight">
+            Tricle
+          </span>
+        </div>
+
+        {/* ナビゲーションアイテム */}
+        <ul className="flex flex-col gap-1">
+          {NAV_ITEMS.map((item) => {
+            const isActive = pathname === item.href;
+            const Icon = item.icon;
+            return (
+              <li key={item.href}>
+                <Link
+                  href={item.href}
+                  className={cn(
+                    "flex items-center gap-3 rounded-xl px-3 py-2.5 text-sm font-medium transition-all duration-200",
+                    isActive
+                      ? "bg-violet-500/20 text-violet-400"
+                      : "text-zinc-400 hover:bg-zinc-800 hover:text-zinc-100",
+                  )}
+                >
+                  <Icon
+                    size={20}
+                    strokeWidth={isActive ? 2.5 : 2}
+                    className={cn(
+                      "shrink-0 transition-all duration-200",
+                      isActive && "[&>*]:fill-current",
+                    )}
+                  />
+                  <span>{item.label}</span>
+                </Link>
+              </li>
+            );
+          })}
+        </ul>
+
+        {/* 投稿ボタン */}
+        <div className="mt-4 px-1">
+          <button
+            type="button"
+            onClick={handleOpenModal}
+            className="flex w-full items-center justify-center gap-2 rounded-full bg-violet-600 px-4 py-2.5 text-sm font-semibold text-white transition-all duration-200 hover:bg-violet-500 active:scale-95 active:bg-violet-700"
+          >
+            <Pencil size={16} strokeWidth={2.5} />
+            <span>投稿する</span>
+          </button>
+        </div>
+      </nav>
+
+      <PostModal isOpen={isModalOpen} onClose={handleCloseModal} />
+    </>
+  );
+};
+
+export default SideNav;


### PR DESCRIPTION
## 概要

現在、レイアウトが `max-w-sm` で固定されており、PC ブラウザでアクセスするとコンテンツがスマホ幅のまま中央に表示される。PC・タブレット向けにレスポンシブなレイアウトを実装する。

## 背景

- `src/app/layout.tsx` の `max-w-sm` 制約によりスマホ幅に固定されている
- `BottomNav` はモバイル専用の画面下部ナビゲーションであり、PC では UX として適切でない
- Tailwind CSS のブレークポイント（`md:`, `lg:`）を活用したモバイルファーストの対応が必要

## 実装方針

### レイアウト全体（`src/app/layout.tsx`）

- `max-w-sm` → PC では `max-w-2xl` 程度に拡張
- `lg:` 以上でサイドバーナビゲーション + メインコンテンツの2カラム構成に変更

### BottomNav（`src/components/ui/BottomNav.tsx`）

- モバイル（`< md`）: 現状の固定底部ナビゲーションをそのまま維持
- PC（`md:` 以上）: 非表示にし、サイドバーナビゲーションに切り替える

### サイドバーナビゲーション（新規: `src/components/ui/SideNav.tsx`）

- `md:` 以上で表示（`hidden md:flex` など）
- 左側固定のサイドバー
- BottomNav と同じナビアイテム（ホーム・サブスク・検索・プロフィール）を縦並びで表示
- アクティブインジケーターは BottomNav と統一したデザイン
- 「投稿」ボタン（FAB と役割統一、PC では FAB を非表示にしてサイドバーに配置）

### FAB（`src/components/ui/FAB.tsx`）

- モバイルのみ表示（`md:hidden`）
- PC ではサイドバー内の「投稿」ボタンからでモーダルを開く

### コンテンツエリア

- PC では左にサイドバー（固定幅）、右にメインコンテンツ（残り幅）
- メインコンテンツの最大幅はモバイル換算に近い幅を維持し、中央寄せ
- 必要に応じてさらに右側に補助カラム（将来拡張用）を設けてもよい

## ブレークポイント方針

| 画面幅 | レイアウト |
|---|---|
| `< md` (767px 以下) | モバイル: BottomNav + FAB |
| `md` 以上 (768px〜) | PC: SideNav + サイドバー内投稿ボタン |

## AC（受け入れ条件）

- [ ] PC（`md:` 以上）でサイドバーナビゲーションが表示される
- [ ] PC でボトムナビゲーションが非表示になる
- [ ] PC で FAB が非表示になり、サイドバーの「投稿」ボタンから投稿モーダルが開く
- [ ] モバイルでは既存の BottomNav・FAB がそのまま動作する
- [ ] コンテンツ幅が PC でも極端に広がらず読みやすい幅に収まる
- [ ] 各ページ（ホーム・サブスク・検索・プロフィール・トピック詳細）でレイアウトが崩れない

## 関連

- BottomNav は Issue #25 で実装済み
- FAB・PostModal は Issue #24 で実装済み