### PR TITLE
feat: ホームタブに「自分の投稿」と「タイムライン」のタブ切り替え UI を追加 (#33)

### DIFF
--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -1,4 +1,4 @@
-import ActivityFeed from "@/components/home/ActivityFeed";
+import HomeTabs from "@/components/home/HomeTabs";
 import FAB from "@/components/ui/FAB";
 
 export default function Home() {
@@ -9,8 +9,8 @@ export default function Home() {
         <h1 className="text-lg font-bold text-zinc-100">ホーム</h1>
       </header>
 
-      <main className="px-4 py-4">
-        <ActivityFeed />
+      <main>
+        <HomeTabs />
       </main>
 
       <FAB />

--- a/src/components/home/HomeTabs.tsx
+++ b/src/components/home/HomeTabs.tsx
@@ -1,0 +1,59 @@
+"use client";
+
+import { useState } from "react";
+import { cn } from "@/lib/utils";
+import ActivityFeed from "./ActivityFeed";
+import TimelineFeed from "./TimelineFeed";
+
+type TabKey = "mine" | "timeline";
+
+type Tab = {
+  key: TabKey;
+  label: string;
+};
+
+const TABS: Tab[] = [
+  { key: "mine", label: "自分の投稿" },
+  { key: "timeline", label: "タイムライン" },
+];
+
+/**
+ * ホームタブ切り替え。
+ * "自分の投稿" / "タイムライン" の 2 タブを管理する Client Component。
+ */
+const HomeTabs = () => {
+  const [activeTab, setActiveTab] = useState<TabKey>("mine");
+
+  const handleTabChange = (key: TabKey) => {
+    setActiveTab(key);
+  };
+
+  return (
+    <div className="flex flex-col">
+      {/* タブバー */}
+      <div className="flex border-b border-zinc-800">
+        {TABS.map((tab) => (
+          <button
+            key={tab.key}
+            onClick={() => handleTabChange(tab.key)}
+            className={cn(
+              "flex-1 py-2.5 text-sm font-medium transition-colors",
+              activeTab === tab.key
+                ? "border-b-2 border-violet-500 text-violet-400"
+                : "text-zinc-500 hover:text-zinc-300",
+            )}
+          >
+            {tab.label}
+          </button>
+        ))}
+      </div>
+
+      {/* フィード */}
+      <div className="px-4 py-4">
+        {activeTab === "mine" ? <ActivityFeed /> : <TimelineFeed />}
+      </div>
+    </div>
+  );
+};
+
+export default HomeTabs;

--- a/src/components/home/TimelineFeed.tsx
+++ b/src/components/home/TimelineFeed.tsx
@@ -1,0 +1,45 @@
+import { activities } from "@/mocks/activities";
+import { topics } from "@/mocks/topics";
+import { users } from "@/mocks/users";
+import ActivityCard from "./ActivityCard";
+
+/**
+ * タイムラインフィード。
+ * 全ユーザーのアクティビティを createdAt 降順（最新が先頭）で表示する。
+ */
+const TimelineFeed = () => {
+  // 全アクティビティを新しい順に並べる
+  const sortedActivities = [...activities].sort(
+    (a, b) =>
+      new Date(b.createdAt).getTime() - new Date(a.createdAt).getTime(),
+  );
+
+  // トピック・ユーザーを O(1) で引けるようにマップ化
+  const topicMap = new Map(topics.map((t) => [t.id, t]));
+  const userMap = new Map(users.map((u) => [u.id, u]));
+
+  if (sortedActivities.length === 0) {
+    return (
+      <p className="text-center text-sm text-zinc-500 py-16">
+        アクティビティがありません
+      </p>
+    );
+  }
+
+  return (
+    <ul className="flex flex-col gap-3">
+      {sortedActivities.map((activity) => {
+        const topic = topicMap.get(activity.topicId);
+        const user = userMap.get(activity.userId);
+        if (!topic || !user) return null;
+        return (
+          <li key={activity.id}>
+            <ActivityCard activity={activity} topic={topic} user={user} />
+          </li>
+        );
+      })}
+    </ul>
+  );
+};
+
+export default TimelineFeed;


### PR DESCRIPTION
## 概要

Issue #33 の実装です。ホームタブ内にタブ切り替え UI を追加し、**「自分の投稿」** と **「タイムライン」** を切り替えられるようにしました。

## 変更内容

### 新規ファイル

- **`src/components/home/HomeTabs.tsx`**
  - `"use client"` 指令付きの Client Component
  - `useState` で `"mine"` / `"timeline"` のタブ状態を管理
  - アンダーラインスタイルのタブバー（アクティブ時は `border-violet-500` + `text-violet-400`）
  - 選択タブに応じて `ActivityFeed` または `TimelineFeed` をレンダリング

- **`src/components/home/TimelineFeed.tsx`**
  - `"use client"` なしの Server Component
  - `activities` モックの全エントリを `createdAt` 降順でソートして表示
  - `topicMap` / `userMap` を `Map` で構築し O(1) ルックアップ
  - 空状態のフォールバック表示あり

### 変更ファイル

- **`src/app/page.tsx`**
  - `ActivityFeed` の直接参照を削除し、`HomeTabs` を埋め込む
  - `<main>` からパディングを除去（`HomeTabs` 内に移動）
  - Server Component のまま維持

## 実装上の判断

- `HomeTabs` を Client Component にし、`ActivityFeed` / `TimelineFeed` をその子として import することで、`page.tsx` を Server Component のまま維持しています
- タブバーのデザインは Issue 指定通りのアンダーラインスタイルとし、ピル型は採用していません
- `TimelineFeed` はモックデータをそのまま使用し、ページネーション/無限スクロールは今 Issue のスコープ外として静的一覧で実装しています

## チェックリスト

- [x] ホームタブ内に「自分の投稿」「タイムライン」のタブが表示される
- [x] 「自分の投稿」タブで従来どおり currentUser の投稿一覧が表示される
- [x] 「タイムライン」タブで全ユーザーの投稿が時系列降順で表示される
- [x] タブ切り替えがスムーズに動作する
- [x] TypeScript エラーなし（`tsc --noEmit` 通過）
- [x] ESLint エラーなし（`npm run lint` 通過）
- [x] `any` 型不使用
- [x] インラインスタイル不使用
- [x] Server Component / Client Component の境界が適切に維持されている
