### PR TITLE
feat: トピックタブに「新規トピックを作成」ボタンを追加する (#37)

### DIFF
--- a/src/app/topics/page.tsx
+++ b/src/app/topics/page.tsx
@@ -1,7 +1,6 @@
-import Image from "next/image";
-import Link from "next/link";
 import { topics } from "@/mocks/topics";
 import { currentUser } from "@/mocks/users";
+import TopicsClient from "@/components/topic/TopicsClient";
 
 // モックのログインユーザーID
 const MY_USER_ID = currentUser.id;
@@ -9,71 +8,7 @@ const MY_USER_ID = currentUser.id;
 const TopicsPage = () => {
   const myTopics = topics.filter((t) => t.userId === MY_USER_ID);
 
-  return (
-    <main className="flex flex-col pb-6">
-      {/* ページヘッダー */}
-      <header className="sticky top-0 z-10 border-b border-zinc-800 bg-zinc-950/80 px-4 py-3 backdrop-blur-sm">
-        <h1 className="text-base font-bold text-zinc-100">トピック</h1>
-      </header>
-
-      <div className="px-4 pt-4">
-        {myTopics.length === 0 ? (
-          <p className="py-12 text-center text-sm text-zinc-500">
-            トピックがありません
-          </p>
-        ) : (
-          <div className="grid grid-cols-2 gap-3">
-            {myTopics.map((topic) => (
-              <Link
-                key={topic.id}
-                href={`/topics/${topic.id}`}
-                className="flex flex-col overflow-hidden rounded-xl bg-zinc-800/60 transition-colors hover:bg-zinc-700/80 active:bg-zinc-700"
-              >
-                {/* テーマ画像 or 絵文字フォールバック */}
-                {topic.imageUrl ? (
-                  <div className="relative aspect-video w-full">
-                    <Image
-                      src={topic.imageUrl}
-                      alt={topic.title}
-                      fill
-                      className="object-cover"
-                      sizes="(max-width: 768px) 50vw, 200px"
-                    />
-                  </div>
-                ) : (
-                  <div className="flex aspect-video w-full items-center justify-center bg-zinc-700/60">
-                    {topic.emoji && (
-                      <span className="text-4xl leading-none" aria-hidden="true">
-                        {topic.emoji}
-                      </span>
-                    )}
-                  </div>
-                )}
-                {/* カード本文 */}
-                <div className="flex flex-col gap-1 p-3">
-                  <div className="flex items-center gap-1.5">
-                    {topic.emoji && (
-                      <span className="text-base leading-none" aria-hidden="true">
-                        {topic.emoji}
-                      </span>
-                    )}
-                    <span className="truncate text-sm font-semibold text-zinc-100">
-                      {topic.title}
-                    </span>
-                  </div>
-                  {topic.description && (
-                    <span className="line-clamp-2 text-xs text-zinc-400">
-                      {topic.description}
-                    </span>
-                  )}
-                </div>
-              </Link>
-            ))}
-          </div>
-        )}
-      </div>
-    </main>
-  );
+  return <TopicsClient initialTopics={myTopics} />;
 };
 
 export default TopicsPage;

--- a/src/components/topic/CreateTopicModal.tsx
+++ b/src/components/topic/CreateTopicModal.tsx
@@ -1,0 +1,164 @@
+"use client";
+
+import { useState } from "react";
+import { X } from "lucide-react";
+import { cn } from "@/lib/utils";
+import type { Topic } from "@/types/topic";
+
+type Props = {
+  isOpen: boolean;
+  onClose: () => void;
+  onCreate: (topic: Topic) => void;
+};
+
+const CreateTopicModal = ({ isOpen, onClose, onCreate }: Props) => {
+  const [title, setTitle] = useState("");
+  const [emoji, setEmoji] = useState("");
+  const [description, setDescription] = useState("");
+
+  const isValid = title.trim().length > 0;
+
+  const handleSubmit = () => {
+    if (!isValid) return;
+
+    const newTopic: Topic = {
+      id: `topic-${crypto.randomUUID()}`,
+      userId: "user-1",
+      title: title.trim(),
+      emoji: emoji.trim() || undefined,
+      description: description.trim() || undefined,
+    };
+
+    onCreate(newTopic);
+    handleClose();
+  };
+
+  const handleClose = () => {
+    setTitle("");
+    setEmoji("");
+    setDescription("");
+    onClose();
+  };
+
+  if (!isOpen) return null;
+
+  return (
+    <>
+      {/* オーバーレイ */}
+      <div
+        className="fixed inset-0 z-50 bg-black/60 backdrop-blur-sm"
+        onClick={handleClose}
+        aria-hidden="true"
+      />
+
+      {/* モーダルパネル */}
+      <div
+        role="dialog"
+        aria-modal="true"
+        aria-label="新規トピックを作成"
+        className="fixed left-1/2 top-1/2 z-50 w-[calc(100%-2rem)] max-w-sm -translate-x-1/2 -translate-y-1/2 rounded-2xl bg-zinc-900 shadow-xl"
+      >
+        {/* ヘッダー */}
+        <div className="flex items-center justify-between px-4 pt-4 pb-2">
+          <h2 className="text-base font-bold text-zinc-100">新規トピックを作成</h2>
+          <button
+            type="button"
+            onClick={handleClose}
+            className="flex h-8 w-8 items-center justify-center rounded-full text-zinc-400 transition-colors hover:bg-zinc-800 hover:text-zinc-100"
+            aria-label="閉じる"
+          >
+            <X size={18} />
+          </button>
+        </div>
+
+        <div className="flex flex-col gap-4 px-4 pb-6 pt-2">
+          {/* タイトル（必須） */}
+          <div className="flex flex-col gap-1.5">
+            <label
+              htmlFor="topic-title"
+              className="text-xs font-medium text-zinc-400"
+            >
+              タイトル
+              <span className="ml-1 text-violet-400">*</span>
+            </label>
+            <input
+              id="topic-title"
+              type="text"
+              value={title}
+              onChange={(e) => setTitle(e.target.value)}
+              placeholder="例：読んだ本"
+              className={cn(
+                "w-full rounded-xl border border-zinc-700 bg-zinc-800 px-4 py-2.5",
+                "text-sm text-zinc-100 placeholder:text-zinc-500 outline-none transition-colors",
+                "focus:border-violet-500 focus:ring-1 focus:ring-violet-500/50",
+              )}
+            />
+          </div>
+
+          {/* 絵文字（任意） */}
+          <div className="flex flex-col gap-1.5">
+            <label
+              htmlFor="topic-emoji"
+              className="text-xs font-medium text-zinc-400"
+            >
+              絵文字
+              <span className="ml-1 text-zinc-600">（任意）</span>
+            </label>
+            <input
+              id="topic-emoji"
+              type="text"
+              value={emoji}
+              onChange={(e) => setEmoji(e.target.value)}
+              placeholder="例：📚"
+              className={cn(
+                "w-full rounded-xl border border-zinc-700 bg-zinc-800 px-4 py-2.5",
+                "text-sm text-zinc-100 placeholder:text-zinc-500 outline-none transition-colors",
+                "focus:border-violet-500 focus:ring-1 focus:ring-violet-500/50",
+              )}
+            />
+          </div>
+
+          {/* 説明文（任意） */}
+          <div className="flex flex-col gap-1.5">
+            <label
+              htmlFor="topic-description"
+              className="text-xs font-medium text-zinc-400"
+            >
+              説明文
+              <span className="ml-1 text-zinc-600">（任意）</span>
+            </label>
+            <textarea
+              id="topic-description"
+              value={description}
+              onChange={(e) => setDescription(e.target.value)}
+              placeholder="このトピックについて説明してください"
+              rows={3}
+              className={cn(
+                "w-full resize-none rounded-xl border border-zinc-700 bg-zinc-800 px-4 py-2.5",
+                "text-sm text-zinc-100 placeholder:text-zinc-500 outline-none transition-colors",
+                "focus:border-violet-500 focus:ring-1 focus:ring-violet-500/50",
+              )}
+            />
+          </div>
+
+          {/* 作成ボタン */}
+          <button
+            type="button"
+            onClick={handleSubmit}
+            disabled={!isValid}
+            className={cn(
+              "w-full rounded-xl py-2.5 text-sm font-semibold transition-colors",
+              isValid
+                ? "bg-violet-600 text-white hover:bg-violet-500 active:bg-violet-700"
+                : "cursor-not-allowed bg-zinc-700 text-zinc-500",
+            )}
+          >
+            作成する
+          </button>
+        </div>
+      </div>
+    </>
+  );
+};
+
+export default CreateTopicModal;

--- a/src/components/topic/TopicsClient.tsx
+++ b/src/components/topic/TopicsClient.tsx
@@ -1,0 +1,105 @@
+"use client";
+
+import { useState } from "react";
+import Image from "next/image";
+import Link from "next/link";
+import { Plus } from "lucide-react";
+import type { Topic } from "@/types/topic";
+import CreateTopicModal from "./CreateTopicModal";
+
+type Props = {
+  initialTopics: Topic[];
+};
+
+const TopicsClient = ({ initialTopics }: Props) => {
+  const [topics, setTopics] = useState<Topic[]>(initialTopics);
+  const [isModalOpen, setIsModalOpen] = useState(false);
+
+  const handleCreate = (newTopic: Topic) => {
+    setTopics((prev) => [newTopic, ...prev]);
+  };
+
+  return (
+    <main className="flex flex-col pb-6">
+      {/* ページヘッダー */}
+      <header className="sticky top-0 z-10 border-b border-zinc-800 bg-zinc-950/80 px-4 py-3 backdrop-blur-sm">
+        <div className="flex items-center justify-between">
+          <h1 className="text-base font-bold text-zinc-100">トピック</h1>
+          <button
+            type="button"
+            onClick={() => setIsModalOpen(true)}
+            className="flex items-center gap-1 rounded-lg px-3 py-1.5 text-sm font-medium text-violet-400 transition-colors hover:bg-violet-600/10 hover:text-violet-300 active:bg-violet-600/20"
+          >
+            <Plus size={16} aria-hidden="true" />
+            新規作成
+          </button>
+        </div>
+      </header>
+
+      <div className="px-4 pt-4">
+        {topics.length === 0 ? (
+          <p className="py-12 text-center text-sm text-zinc-500">
+            トピックがありません
+          </p>
+        ) : (
+          <div className="grid grid-cols-2 gap-3">
+            {topics.map((topic) => (
+              <Link
+                key={topic.id}
+                href={`/topics/${topic.id}`}
+                className="flex flex-col overflow-hidden rounded-xl bg-zinc-800/60 transition-colors hover:bg-zinc-700/80 active:bg-zinc-700"
+              >
+                {/* テーマ画像 or 絵文字フォールバック */}
+                {topic.imageUrl ? (
+                  <div className="relative aspect-video w-full">
+                    <Image
+                      src={topic.imageUrl}
+                      alt={topic.title}
+                      fill
+                      className="object-cover"
+                      sizes="(max-width: 768px) 50vw, 200px"
+                    />
+                  </div>
+                ) : (
+                  <div className="flex aspect-video w-full items-center justify-center bg-zinc-700/60">
+                    {topic.emoji && (
+                      <span className="text-4xl leading-none" aria-hidden="true">
+                        {topic.emoji}
+                      </span>
+                    )}
+                  </div>
+                )}
+                {/* カード本文 */}
+                <div className="flex flex-col gap-1 p-3">
+                  <div className="flex items-center gap-1.5">
+                    {topic.emoji && (
+                      <span className="text-base leading-none" aria-hidden="true">
+                        {topic.emoji}
+                      </span>
+                    )}
+                    <span className="truncate text-sm font-semibold text-zinc-100">
+                      {topic.title}
+                    </span>
+                  </div>
+                  {topic.description && (
+                    <span className="line-clamp-2 text-xs text-zinc-400">
+                      {topic.description}
+                    </span>
+                  )}
+                </div>
+              </Link>
+            ))}
+          </div>
+        )}
+      </div>
+
+      <CreateTopicModal
+        isOpen={isModalOpen}
+        onClose={() => setIsModalOpen(false)}
+        onCreate={handleCreate}
+      />
+    </main>
+  );
+};
+
+export default TopicsClient;


### PR DESCRIPTION
## 概要

トピックタブ（`/topics`）のヘッダー右端に「新規作成」ボタンを追加し、モーダルから新しいトピックを作成できるようにする。

Closes #37

## 変更内容

### `src/components/topic/CreateTopicModal.tsx`（新規）

- タイトル（必須）・絵文字（任意）・説明文（任意）の 3 フィールドを持つ作成モーダル
- タイトルが空の間は「作成する」ボタンを `disabled` にして送信を防止
- モーダルを閉じる（×ボタン・オーバーレイクリック・作成完了）際に全フィールドをリセット
- ID 生成は `crypto.randomUUID()` を使用（ESLint `react-hooks/purity` 準拠）
- `"use client"` 指令付きの Client Component

### `src/components/topic/TopicsClient.tsx`（新規）

- トピック一覧 + ヘッダーボタン + モーダルの状態を管理する Client Component
- `initialTopics: Topic[]` を props で受け取り、`useState` でローカルに管理
- 新規作成されたトピックを先頭に追加（`setTopics((prev) => [newTopic, ...prev])`）
- 「新規作成」ボタンは `violet-400` + `<Plus>` アイコン、ヘッダー右端に配置

### `src/app/topics/page.tsx`（変更）

- Server Component のまま維持（`"use client"` 不要）
- モックデータのフィルタリングのみを行い、`<TopicsClient initialTopics={myTopics} />` に委譲するシンプルな構成に変更

## 完了条件チェック

- [x] ヘッダー右端に「新規作成」ボタンが表示される
- [x] ボタン押下でトピック作成モーダルが開く
- [x] タイトル・絵文字・説明文を入力して作成すると、トピック一覧に追加される
- [x] 必須項目（タイトル）が空の場合は作成ボタンを無効化する
- [x] モーダルを閉じると入力内容がリセットされる
- [x] TypeScript エラーなし・ESLint エラーなし
- [x] Server Component / Client Component の境界が適切に維持されている

## 実装メモ

- `page.tsx` を Client Component に昇格させず、`TopicsClient` を切り出すことで Server Component 比率を維持
- `any` 型不使用・インラインスタイル不使用
- 作成したトピックはページリロードでリセットされる仕様（バックエンドなしのため）
- `imageUrl` の設定は別 Issue のスコープのため未対応
