### PR TITLE
feat(subscriptions): faceId ベースに移行・オンボーディング UI 追加 (#49)

### DIFF
--- a/src/app/subscriptions/page.tsx
+++ b/src/app/subscriptions/page.tsx
@@ -1,5 +1,5 @@
 import SubscriptionFeed from "@/components/subscriptions/SubscriptionFeed";
-import { subscribedFaceIds } from "@/mocks/subscriptions";
+import { subscriptionRepository } from "@/repositories/subscription-repository";
 import FAB from "@/components/ui/FAB";
 
 export default function SubscriptionsPage() {
@@ -10,7 +10,7 @@ export default function SubscriptionsPage() {
         <div className="flex items-center justify-between">
           <h1 className="text-lg font-bold text-zinc-100">サブスク</h1>
           <span className="text-xs text-zinc-500">
-            {subscribedFaceIds.length} フェイスをサブスク中
+            {subscriptionRepository.getSubscribedFaceIds().length} フェイスをサブスク中
           </span>
         </div>
       </header>

--- a/src/components/subscriptions/SubscriptionFeed.tsx
+++ b/src/components/subscriptions/SubscriptionFeed.tsx
@@ -1,39 +1,49 @@
-import { activities } from "@/mocks/activities";
-import { topics } from "@/mocks/topics";
-import { users } from "@/mocks/users";
-import { subscribedFaceIds } from "@/mocks/subscriptions";
+import Link from "next/link";
+import { activityRepository } from "@/repositories/activity-repository";
+import { faceRepository } from "@/repositories/face-repository";
+import { userRepository } from "@/repositories/user-repository";
+import { subscriptionRepository } from "@/repositories/subscription-repository";
 import ActivityCard from "@/components/ui/ActivityCard";
 
 /**
  * サブスク画面フィード。
- * currentUser がサブスクライブしているトピックのアクティビティを
+ * currentUser がサブスクライブしているフェイスのアクティビティを
  * 時系列降順（最新が先頭）で表示する。
  *
- * 各カードには「誰の・何のトピックの投稿か」を明示する。
+ * 各カードには「誰の・何のフェイスの投稿か」を明示する。
  */
 const SubscriptionFeed = () => {
-  // サブスクライブ中トピックのアクティビティを新しい順に並べる
-  const subscribedActivities = activities
-    .filter((a) => subscribedFaceIds.includes(a.faceId))
-    .sort(
-      (a, b) =>
-        new Date(b.createdAt).getTime() - new Date(a.createdAt).getTime(),
-    );
+  // サブスクライブ中フェイスID一覧をリポジトリ経由で取得
+  const subscribedFaceIds = subscriptionRepository.getSubscribedFaceIds();
+
+  // サブスクライブ中フェイスのアクティビティを新しい順に取得
+  const subscribedActivities = activityRepository.listByFaceIds(subscribedFaceIds);
 
   // O(1) で引けるようにマップ化
-  const topicMap = new Map(topics.map((t) => [t.id, t]));
-  const userMap = new Map(users.map((u) => [u.id, u]));
+  const faceMap = new Map(
+    subscribedFaceIds
+      .map((id) => [id, faceRepository.findById(id)] as const)
+      .filter((entry): entry is [string, NonNullable<ReturnType<typeof faceRepository.findById>>] =>
+        entry[1] !== undefined
+      )
+  );
+  const userMap = new Map(
+    userRepository.listAll().map((u) => [u.id, u])
+  );
 
   if (subscribedActivities.length === 0) {
     return (
-      <div className="flex flex-col items-center gap-3 py-20 text-center">
-        <p className="text-3xl">🔔</p>
+      <div className="flex flex-col items-center gap-4 py-20 text-center">
+        <p className="text-4xl">🔔</p>
         <p className="text-sm text-zinc-400">
-          サブスクライブ中のトピックがありません
+          まだサブスクしているフェイスがありません
         </p>
-        <p className="text-xs text-zinc-600">
-          トピック詳細画面からサブスクライブできます
-        </p>
+        <Link
+          href="/search"
+          className="rounded-full bg-violet-600 px-5 py-2 text-sm font-semibold text-white transition hover:bg-violet-500 active:bg-violet-700"
+        >
+          検索してフェイスを探す
+        </Link>
       </div>
     );
   }
@@ -41,16 +51,16 @@ const SubscriptionFeed = () => {
   return (
     <ul className="flex flex-col gap-3">
       {subscribedActivities.map((activity) => {
-        const topic = topicMap.get(activity.faceId);
+        const face = faceMap.get(activity.faceId);
         const user = userMap.get(activity.userId);
-        if (!topic || !user) return null;
+        if (!face || !user) return null;
         return (
           <li key={activity.id}>
             <ActivityCard
               activity={activity}
               user={user}
-              topicTitle={`${topic.emoji ?? ""} ${topic.title}`.trim()}
-              topicId={topic.id}
+              topicTitle={`${face.emoji ?? ""} ${face.name}`.trim()}
+              topicId={face.id}
             />
           </li>
         );


### PR DESCRIPTION
## 概要

Issue #49 の対応。サブスクタブを `topicId` ベースから `faceId` ベースへ移行し、サブスク0件時のオンボーディング UI を追加する。

## 変更内容

### `src/components/subscriptions/SubscriptionFeed.tsx`

- モックからの直接 import を全廃し、Repository パターンへ移行
  - `activities` → `activityRepository.listByFaceIds(subscribedFaceIds)`
  - `topics` / `topicMap` → `faceRepository.findById()` を使った `faceMap` に変更
  - `users` / `userMap` → `userRepository.listAll()` を使った `userMap` に変更
  - `subscribedFaceIds` → `subscriptionRepository.getSubscribedFaceIds()` に変更
- `ActivityCard` へ渡すデータを `topic.title` → `face.name`、`topic.emoji` → `face.emoji` に更新
- サブスク0件時のオンボーディング UI を刷新
  - 「まだサブスクしているフェイスがありません」メッセージ
  - 「検索してフェイスを探す」ボタン（`/search` へのリンク）

### `src/app/subscriptions/page.tsx`

- `subscribedFaceIds` の直接 import を廃止
- `subscriptionRepository.getSubscribedFaceIds().length` でサブスク数を表示

## 動作確認

- [ ] サブスクフィードが正常に表示される（`faceId` ベースで絞り込み）
- [ ] サブスク0件時にオンボーディング UI（メッセージ + 検索リンク）が表示される
- [ ] TypeScript エラーなし（`tsc --noEmit` 通過）
- [ ] ESLint エラーなし

## 完了条件（Issue AC）

- [x] サブスクフィードが `faceId` ベースで動作している
- [x] サブスク0件時にオンボーディング UI が表示される

## 関連

- Closes #49
- 依存: Step 3（Repository 層）, Step 2（`subscribedFaceIds` モックデータ）
