### PR TITLE
feat: 通知タブの新規実装 (#50)

### DIFF
--- a/src/app/notifications/page.tsx
+++ b/src/app/notifications/page.tsx
@@ -1,0 +1,24 @@
+import NotificationList from "@/components/notifications/NotificationList";
+import { notificationRepository } from "@/repositories/notification-repository";
+
+export default function NotificationsPage() {
+  const count = notificationRepository.listAll().length;
+
+  return (
+    <div className="flex flex-col">
+      {/* スティッキーヘッダー */}
+      <header className="sticky top-0 z-10 border-b border-zinc-800 bg-zinc-950/80 px-4 py-3 backdrop-blur-sm">
+        <div className="flex items-center justify-between">
+          <h1 className="text-lg font-bold text-zinc-100">通知</h1>
+          {count > 0 && (
+            <span className="text-xs text-zinc-500">{count} 件</span>
+          )}
+        </div>
+      </header>
+
+      <main className="px-4 py-4">
+        <NotificationList />
+      </main>
+    </div>
+  );
+}

--- a/src/components/notifications/NotificationList.tsx
+++ b/src/components/notifications/NotificationList.tsx
@@ -1,0 +1,152 @@
+import Avatar from "@/components/ui/Avatar";
+import { notificationRepository } from "@/repositories/notification-repository";
+import { userRepository } from "@/repositories/user-repository";
+import { faceRepository } from "@/repositories/face-repository";
+import { activityRepository } from "@/repositories/activity-repository";
+import { type Notification } from "@/types/notification";
+import { type User } from "@/types/user";
+
+// ─── ヘルパー ──────────────────────────────────────────────────
+
+/** ISO 8601 文字列を「N分前」「N時間前」「N日前」に変換 */
+const formatRelativeTime = (isoString: string): string => {
+  const now = new Date();
+  const date = new Date(isoString);
+  const diffMs = now.getTime() - date.getTime();
+  const diffMin = Math.floor(diffMs / 60_000);
+  const diffHour = Math.floor(diffMin / 60);
+  const diffDay = Math.floor(diffHour / 24);
+
+  if (diffMin < 1) return "たった今";
+  if (diffMin < 60) return `${diffMin}分前`;
+  if (diffHour < 24) return `${diffHour}時間前`;
+  if (diffDay < 30) return `${diffDay}日前`;
+
+  return date.toLocaleDateString("ja-JP", {
+    year: "numeric",
+    month: "short",
+    day: "numeric",
+  });
+};
+
+// ─── 通知アイテム ──────────────────────────────────────────────
+
+type NotificationItemProps = {
+  notification: Notification;
+  fromUser: User;
+  detail: string;
+  /** リンク通知の場合のアクティビティ本文スニペット（任意） */
+  activitySnippet?: string;
+};
+
+const NotificationItem = ({
+  notification,
+  fromUser,
+  detail,
+  activitySnippet,
+}: NotificationItemProps) => {
+  const isLink = notification.type === "link";
+
+  return (
+    <li className="flex gap-3 rounded-2xl bg-zinc-800/60 p-4 transition hover:bg-zinc-800">
+      {/* アバター */}
+      <div className="shrink-0">
+        <Avatar src={fromUser.avatarUrl} alt={fromUser.name} size="md" />
+      </div>
+
+      {/* 本文 */}
+      <div className="flex flex-1 flex-col gap-1.5 overflow-hidden">
+        {/* アクション行 */}
+        <div className="flex items-start justify-between gap-2">
+          <p className="text-sm text-zinc-200 leading-snug">
+            <span className="font-semibold text-zinc-100">{fromUser.name}</span>
+            {" さんが "}
+            <span className="text-violet-400">{detail}</span>
+          </p>
+          <span className="shrink-0 text-xs text-zinc-500">
+            {formatRelativeTime(notification.createdAt)}
+          </span>
+        </div>
+
+        {/* リンク通知: アクティビティ本文スニペット */}
+        {isLink && activitySnippet && (
+          <blockquote className="rounded-lg border-l-2 border-violet-500/60 bg-zinc-900/60 px-3 py-2 text-xs text-zinc-400 line-clamp-2">
+            {activitySnippet}
+          </blockquote>
+        )}
+
+        {/* 通知種別バッジ */}
+        <span className="self-start rounded-full bg-zinc-700/60 px-2 py-0.5 text-xs text-zinc-400">
+          {isLink ? "🔗 リンク" : "📥 サブスク"}
+        </span>
+      </div>
+    </li>
+  );
+};
+
+// ─── NotificationList ──────────────────────────────────────────
+
+/**
+ * 通知一覧コンポーネント（Server Component）。
+ * notificationRepository から全通知を取得し、時系列降順で表示する。
+ */
+const NotificationList = () => {
+  const notifications = notificationRepository.listAll();
+
+  // ユーザー情報をマップ化
+  const userMap = new Map(userRepository.listAll().map((u) => [u.id, u]));
+
+  // アクティビティをマップ化（リンク通知のスニペット表示用）
+  const activityMap = new Map(
+    activityRepository.listAll().map((a) => [a.id, a])
+  );
+
+  if (notifications.length === 0) {
+    return (
+      <div className="flex flex-col items-center gap-4 py-20 text-center">
+        <p className="text-4xl">🔔</p>
+        <p className="text-sm text-zinc-400">まだ通知はありません</p>
+      </div>
+    );
+  }
+
+  return (
+    <ul className="flex flex-col gap-3">
+      {notifications.map((notification) => {
+        const fromUser = userMap.get(notification.fromUserId);
+        if (!fromUser) return null;
+
+        if (notification.type === "link") {
+          const activity = activityMap.get(notification.activityId);
+          const detail = "あなたの投稿をリンクしました";
+          return (
+            <NotificationItem
+              key={notification.id}
+              notification={notification}
+              fromUser={fromUser}
+              detail={detail}
+              activitySnippet={activity?.body}
+            />
+          );
+        }
+
+        // subscribe
+        const face = faceRepository.findById(notification.faceId);
+        const faceName = face
+          ? `${face.emoji ?? ""} ${face.name}`.trim()
+          : notification.faceId;
+        const detail = `${faceName} をサブスクライブしました`;
+        return (
+          <NotificationItem
+            key={notification.id}
+            notification={notification}
+            fromUser={fromUser}
+            detail={detail}
+          />
+        );
+      })}
+    </ul>
+  );
+};
+
+export default NotificationList;

--- a/src/mocks/notifications.ts
+++ b/src/mocks/notifications.ts
@@ -1,0 +1,54 @@
+import { type Notification } from "@/types/notification";
+
+/**
+ * currentUser（山田 太郎 / user-1）宛の通知ダミーデータ。
+ *
+ * - link: 誰かが user-1 のアクティビティをリンクした
+ * - subscribe: 誰かが user-1 のフェイスをサブスクライブした
+ *
+ * createdAt 降順（最新が先頭）で定義。
+ */
+export const notifications: Notification[] = [
+  {
+    id: "notif-1",
+    type: "subscribe",
+    fromUserId: "user-4",
+    faceId: "topic-1-1",
+    createdAt: "2026-03-30T09:12:00+09:00",
+  },
+  {
+    id: "notif-2",
+    type: "link",
+    fromUserId: "user-2",
+    activityId: "act-1-1-7",
+    createdAt: "2026-03-28T18:45:00+09:00",
+  },
+  {
+    id: "notif-3",
+    type: "subscribe",
+    fromUserId: "user-3",
+    faceId: "topic-1-2",
+    createdAt: "2026-03-25T14:00:00+09:00",
+  },
+  {
+    id: "notif-4",
+    type: "link",
+    fromUserId: "user-3",
+    activityId: "act-1-1-6",
+    createdAt: "2026-03-20T21:30:00+09:00",
+  },
+  {
+    id: "notif-5",
+    type: "subscribe",
+    fromUserId: "user-2",
+    faceId: "topic-1-1",
+    createdAt: "2026-03-15T10:22:00+09:00",
+  },
+  {
+    id: "notif-6",
+    type: "link",
+    fromUserId: "user-4",
+    activityId: "act-1-1-5",
+    createdAt: "2026-03-10T08:05:00+09:00",
+  },
+];

--- a/src/repositories/notification-repository.ts
+++ b/src/repositories/notification-repository.ts
@@ -1,0 +1,20 @@
+import { type Notification } from "@/types/notification";
+import { notifications } from "@/mocks/notifications";
+
+// ─── 型（インターフェース）定義 ─────────────────────────────────
+
+/** NotificationRepository が提供するメソッドの型定義 */
+export type NotificationRepository = {
+  /** 全通知を createdAt 降順で取得 */
+  listAll: () => Notification[];
+};
+
+// ─── モック実装 ────────────────────────────────────────────────
+
+export const notificationRepository: NotificationRepository = {
+  listAll: () => {
+    return [...notifications].sort(
+      (a, b) => new Date(b.createdAt).getTime() - new Date(a.createdAt).getTime()
+    );
+  },
+};

--- a/src/types/notification.ts
+++ b/src/types/notification.ts
@@ -1,0 +1,15 @@
+export type Notification =
+  | {
+      id: string;
+      type: "link";
+      fromUserId: string;
+      activityId: string;
+      createdAt: string;
+    }
+  | {
+      id: string;
+      type: "subscribe";
+      fromUserId: string;
+      faceId: string;
+      createdAt: string;
+    };


### PR DESCRIPTION
## 概要

Issue #50 の対応。MultiFace 固有の通知タブ（`/notifications`）を新規実装する。
リンク通知・サブスク通知の2種類を時系列降順で表示する。

## 変更内容

### `src/types/notification.ts`（新規）

- `Notification` 型をユニオン型で定義
  - `{ type: "link"; fromUserId; activityId; ... }`
  - `{ type: "subscribe"; fromUserId; faceId; ... }`

### `src/mocks/notifications.ts`（新規）

- `currentUser`（user-1）宛のダミー通知データを6件作成
  - リンク通知3件（user-2・user-3・user-4 → user-1 のアクティビティへのリンク）
  - サブスク通知3件（user-2・user-3・user-4 → user-1 のフェイスへのサブスク）

### `src/repositories/notification-repository.ts`（新規）

- `NotificationRepository` 型（`listAll()` メソッドを持つ）を定義
- モック実装: `notifications` を `createdAt` 降順でソートして返却

### `src/components/notifications/NotificationList.tsx`（新規）

- 通知を時系列降順で表示する Server Component
- `notificationRepository.listAll()` でデータ取得（mocks 直接 import なし）
- リンク通知: アクティビティ本文スニペットをブロッククォートで表示
- サブスク通知: フェイス名（絵文字付き）を表示
- 0件時の空状態 UI（「まだ通知はありません」メッセージ）

### `src/app/notifications/page.tsx`（新規）

- `/notifications` ページを Server Component として実装
- スティッキーヘッダーに通知件数を表示
- `NotificationList` を呼び出してフィードを描画

## 動作確認

- [x] `/notifications` でリンク通知・サブスク通知が表示される
- [x] 通知が時系列降順（最新が先頭）で表示される
- [x] TypeScript エラーなし（`tsc --noEmit` 通過）
- [x] ESLint エラーなし
- [x] `src/mocks/` をコンポーネント・ページから直接 import していない（Repository 経由）
- [x] `any` 型不使用・インラインスタイル不使用

## 完了条件（Issue AC）

- [x] `/notifications` でリンク通知・サブスク通知が表示される
- [x] 通知が時系列降順（最新が先頭）で表示される

## 関連

- Closes #50
- 依存: Step 3（Repository 層）, Step 4（ナビゲーション）
