### PR TITLE
feat(ui): TopBarコンポーネントを新規実装

### DIFF
--- a/src/components/ui/TopBar.tsx
+++ b/src/components/ui/TopBar.tsx
@@ -35,7 +35,9 @@ const TopBar = ({ pageTitle }: TopBarProps) => {
         </button>
       </header>
 
-      <PostModal isOpen={isPostModalOpen} onClose={handleClose} />
+      {isPostModalOpen && (
+        <PostModal isOpen={isPostModalOpen} onClose={handleClose} />
+      )}
     </>
   );
 };

--- a/src/components/ui/TopBar.tsx
+++ b/src/components/ui/TopBar.tsx
@@ -1,13 +1,42 @@
+"use client";
+
+import { useState } from "react";
+import { Pencil } from "lucide-react";
+import PostModal from "@/components/ui/PostModal";
+
+type TopBarProps = {
+  pageTitle?: string;
+};
+
 /**
  * TopBar（グローバル上部バー）
  * PC 表示時に SideNav の右側、MainColumn・DetailPanel の上部に共通表示される。
- * 詳細な実装は Issue #3 で行う。
  */
-const TopBar = () => {
+const TopBar = ({ pageTitle }: TopBarProps) => {
+  const [isPostModalOpen, setIsPostModalOpen] = useState(false);
+
+  const handleOpen = () => setIsPostModalOpen(true);
+  const handleClose = () => setIsPostModalOpen(false);
+
   return (
-    <header className="hidden md:flex items-center sticky top-0 z-10 h-12 border-b border-zinc-800 bg-zinc-950/80 backdrop-blur-sm px-4">
-      {/* Issue #3 で実装予定 */}
-    </header>
+    <>
+      <header className="hidden md:flex items-center justify-between sticky top-0 z-10 h-12 border-b border-zinc-800 bg-zinc-950/80 backdrop-blur-sm px-4">
+        {/* 左側: 現在のページ名 */}
+        <span className="text-sm font-semibold text-zinc-400">{pageTitle}</span>
+
+        {/* 右側: 投稿ボタン */}
+        <button
+          type="button"
+          onClick={handleOpen}
+          className="flex items-center gap-2 rounded-full bg-violet-600 px-4 py-1.5 text-sm font-semibold text-white shadow-md shadow-violet-900/40 hover:bg-violet-500 active:scale-95 active:bg-violet-700 transition-all"
+        >
+          <Pencil size={16} strokeWidth={2.5} />
+          投稿する
+        </button>
+      </header>
+
+      <PostModal isOpen={isPostModalOpen} onClose={handleClose} />
+    </>
   );
 };
 


### PR DESCRIPTION
## 概要

PC専用の共通上部バー `TopBar` コンポーネントのプレースホルダー実装を、Issue #78 の仕様に基づいて完全実装しました。  
投稿ボタンのクリックで `PostModal` を開く機能を提供します。

## 関連Issue

Closes #78

## 変更点

- `src/components/ui/TopBar.tsx` を実装
  - `"use client"` ディレクティブを追加（`PostModal` 連携のため）
  - `pageTitle?: string` Propsを追加し、左側にページ名を表示
  - 右側に「投稿する」ボタン（Pencilアイコン + violet-600）を追加
  - クリックで `PostModal` を開くステート管理 (`isPostModalOpen`) を実装
  - レイアウト仕様（`h-12`, `sticky top-0 z-10`, `bg-zinc-950/80 backdrop-blur-sm`, `border-b border-zinc-800`）に準拠

## 動作確認

- [ ] PC表示（md以上）でTopBarが上部に固定表示される
- [ ] モバイル表示（md未満）でTopBarが非表示になる
- [ ] 「投稿する」ボタンクリックでPostModalが開く
- [ ] PostModal内でキャンセル・投稿後にモーダルが閉じる
- [ ] `layout.tsx` から `pageTitle` を渡さない場合、左側が空欄になる
