### PR TITLE
feat(ui): DetailPanelコンポーネントにPropsとプレースホルダーを追加

### DIFF
--- a/src/components/ui/DetailPanel.tsx
+++ b/src/components/ui/DetailPanel.tsx
@@ -1,17 +1,44 @@
+import React from "react";
+
+type DetailPanelProps = {
+  content?: React.ReactNode;
+  placeholderEmoji?: string;
+  placeholderMessage?: string;
+};
+
+type DetailPanelPlaceholderProps = {
+  emoji: string;
+  message?: string;
+};
+
+/**
+ * DetailPanel 未選択時のプレースホルダー
+ */
+const DetailPanelPlaceholder = ({ emoji, message }: DetailPanelPlaceholderProps) => {
+  return (
+    <div className="flex flex-col items-center justify-center h-full gap-3 px-8 text-center">
+      <span className="text-4xl text-zinc-700">{emoji}</span>
+      {message && <p className="text-sm text-zinc-600">{message}</p>}
+    </div>
+  );
+};
+
 /**
  * DetailPanel（右カラム詳細パネル）
  * PC 表示時に MainColumn の右側に固定表示される。
  * 中央カラムで選択したアイテムの詳細を表示する。
- * 詳細な実装は Issue #4 で行う。
+ * content が渡された場合はそれを表示し、未選択時はプレースホルダーを表示する。
  */
-const DetailPanel = () => {
+const DetailPanel = ({
+  content,
+  placeholderEmoji = "🗂️",
+  placeholderMessage,
+}: DetailPanelProps) => {
   return (
-    <aside className="hidden md:flex w-96 shrink-0 overflow-y-auto flex-col">
-      {/* 未選択時プレースホルダー（Issue #4 で詳細実装予定） */}
-      <div className="flex flex-col items-center justify-center h-full gap-3 text-center px-8">
-        <span className="text-4xl text-zinc-700">👈</span>
-        <p className="text-sm text-zinc-600">← 左のリストから選択してください</p>
-      </div>
+    <aside className="hidden md:flex flex-col w-96 shrink-0 overflow-y-auto h-[calc(100vh-3rem)]">
+      {content ?? (
+        <DetailPanelPlaceholder emoji={placeholderEmoji} message={placeholderMessage} />
+      )}
     </aside>
   );
 };

--- a/src/components/ui/DetailPanel.tsx
+++ b/src/components/ui/DetailPanel.tsx
@@ -1,7 +1,7 @@
-import React from "react";
+import type { ReactNode } from "react";
 
 type DetailPanelProps = {
-  content?: React.ReactNode;
+  content?: ReactNode;
   placeholderEmoji?: string;
   placeholderMessage?: string;
 };


### PR DESCRIPTION
## 概要

PC 専用の右カラム `DetailPanel` コンポーネントを仕様通りに再実装。  
Props・型定義・プレースホルダーコンポーネントの追加により、将来の状態管理連携（Issue #80）・詳細コンポーネント（Issue #81/#82）との統合基盤を整備した。

## 関連 Issue

Closes #79

## 変更点

### `src/components/ui/DetailPanel.tsx`

- **`DetailPanelProps` 型を追加**  
  `content?: React.ReactNode`・`placeholderEmoji?: string`・`placeholderMessage?: string` の3プロパティを定義

- **`DetailPanelPlaceholder` 内部コンポーネントを追加**  
  絵文字 + メッセージを縦中央揃えで表示するプレースホルダーUIを実装

- **`DetailPanel` コンポーネントを仕様通りに更新**  
  - `aside` のクラスを `hidden md:flex flex-col w-96 shrink-0 overflow-y-auto h-[calc(100vh-3rem)]` に変更  
  - `content` が渡された場合はそれを表示、なければプレースホルダーを表示（`??` 演算子による切り替え）  
  - デフォルト絵文字: `🗂️`

## 動作確認

- [ ] PC 表示（md: 以上）で `DetailPanel` が右カラムに表示される
- [ ] `content` prop なし時にプレースホルダー（絵文字 + メッセージ）が表示される
- [ ] `content` prop あり時にプレースホルダーが非表示になり、`content` が表示される
- [ ] モバイル表示で `DetailPanel` が非表示（`hidden`）になる
