### PR TITLE
feat(detail-panel): DetailPanel状態管理Contextの実装

### DIFF
--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -5,6 +5,7 @@ import BottomNav from "@/components/ui/BottomNav";
 import SideNav from "@/components/ui/SideNav";
 import TopBar from "@/components/ui/TopBar";
 import DetailPanel from "@/components/ui/DetailPanel";
+import { DetailPanelProvider } from "@/lib/detail-panel-context";
 
 const geistSans = Geist({
   variable: "--font-geist-sans",
@@ -30,19 +31,21 @@ export default function RootLayout({
       <body className="min-h-full bg-zinc-950 text-zinc-100">
         {/* PC: SideNav（左）+ TopBar / MainColumn / DetailPanel（右）の3カラム */}
         {/* モバイル: BottomNav + 1カラム */}
-        <div className="flex min-h-screen w-full">
-          <SideNav />
-          <div className="flex flex-col flex-1 min-w-0">
-            <TopBar />
-            <div className="flex flex-1 overflow-hidden">
-              <main className="flex-1 min-w-0 overflow-y-auto border-r border-zinc-800 pb-16 md:pb-0">
-                {children}
-              </main>
-              <DetailPanel />
+        <DetailPanelProvider>
+          <div className="flex min-h-screen w-full">
+            <SideNav />
+            <div className="flex flex-col flex-1 min-w-0">
+              <TopBar />
+              <div className="flex flex-1 overflow-hidden">
+                <main className="flex-1 min-w-0 overflow-y-auto border-r border-zinc-800 pb-16 md:pb-0">
+                  {children}
+                </main>
+                <DetailPanel />
+              </div>
             </div>
           </div>
-        </div>
-        <BottomNav />
+          <BottomNav />
+        </DetailPanelProvider>
       </body>
     </html>
   );

--- a/src/lib/detail-panel-context.tsx
+++ b/src/lib/detail-panel-context.tsx
@@ -1,0 +1,47 @@
+"use client";
+
+import { createContext, useContext, useState } from "react";
+import type { DetailPanelState } from "@/types/detail-panel";
+
+type DetailPanelContextValue = {
+  state: DetailPanelState;
+  openActivity: (activityId: string) => void;
+  openFace: (faceId: string) => void;
+  close: () => void;
+};
+
+const DetailPanelContext = createContext<DetailPanelContextValue | null>(null);
+
+export const DetailPanelProvider = ({
+  children,
+}: {
+  children: React.ReactNode;
+}) => {
+  const [state, setState] = useState<DetailPanelState>({ type: "none" });
+
+  const openActivity = (activityId: string) => {
+    setState({ type: "activity", activityId });
+  };
+
+  const openFace = (faceId: string) => {
+    setState({ type: "face", faceId });
+  };
+
+  const close = () => {
+    setState({ type: "none" });
+  };
+
+  return (
+    <DetailPanelContext.Provider value={{ state, openActivity, openFace, close }}>
+      {children}
+    </DetailPanelContext.Provider>
+  );
+};
+
+export const useDetailPanel = (): DetailPanelContextValue => {
+  const context = useContext(DetailPanelContext);
+  if (!context) {
+    throw new Error("useDetailPanel は DetailPanelProvider の内側で使用してください");
+  }
+  return context;
+};

--- a/src/types/detail-panel.ts
+++ b/src/types/detail-panel.ts
@@ -1,0 +1,4 @@
+export type DetailPanelState =
+  | { type: "none" }
+  | { type: "activity"; activityId: string }
+  | { type: "face"; faceId: string };


### PR DESCRIPTION
## 概要

DetailPanel に表示するコンテンツの選択状態を管理する React Context を実装した。
どのページからでも「何が選択されているか」を保持し、SideNav・各ページの中央カラムから更新できる。

## 関連 Issue

Closes #80

## 変更点

### `src/types/detail-panel.ts`（新規作成）

- `DetailPanelState` 型を定義
- `{ type: "none" }` / `{ type: "activity"; activityId: string }` / `{ type: "face"; faceId: string }` の判別共用体として設計

### `src/lib/detail-panel-context.tsx`（新規作成）

- `DetailPanelContextValue` 型を定義（`state` / `openActivity` / `openFace` / `close`）
- `DetailPanelProvider` コンポーネントを実装（`useState` で状態を管理）
- `useDetailPanel()` フックをエクスポート（Provider 外で使用するとエラーをスロー）

### `src/app/layout.tsx`（変更）

- `<body>` 直下の全体を `<DetailPanelProvider>` でラップ
- アプリ全体から `useDetailPanel()` が利用可能な状態に

## 動作確認

- [ ] TypeScript のコンパイルエラーがないこと
- [ ] `useDetailPanel()` を Provider 外で呼び出すと適切なエラーが表示されること
- [ ] `openActivity` / `openFace` / `close` 呼び出しで `state` が正しく更新されること
