### PR TITLE
feat: FaceDetailコンポーネント新規作成

### DIFF
--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -24,3 +24,27 @@ body {
   color: var(--foreground);
   font-family: Arial, Helvetica, sans-serif;
 }
+
+/* スクロールバーを細く・控えめに */
+::-webkit-scrollbar {
+  width: 4px;
+}
+
+::-webkit-scrollbar-track {
+  background: transparent;
+}
+
+::-webkit-scrollbar-thumb {
+  background: #3f3f46; /* zinc-700 */
+  border-radius: 9999px;
+}
+
+::-webkit-scrollbar-thumb:hover {
+  background: #71717a; /* zinc-500 */
+}
+
+/* Firefox */
+* {
+  scrollbar-width: thin;
+  scrollbar-color: #3f3f46 transparent;
+}

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -32,11 +32,11 @@ export default function RootLayout({
         {/* PC: SideNav（左）+ TopBar / MainColumn / DetailPanel（右）の3カラム */}
         {/* モバイル: BottomNav + 1カラム */}
         <DetailPanelProvider>
-          <div className="flex min-h-screen w-full">
+          <div className="flex h-screen w-full overflow-hidden">
             <SideNav />
-            <div className="flex flex-col flex-1 min-w-0">
+            <div className="flex flex-col flex-1 min-w-0 overflow-hidden">
               <TopBar />
-              <div className="flex flex-1 overflow-hidden">
+              <div className="flex flex-1 min-h-0 overflow-hidden">
                 <main className="flex-1 min-w-0 overflow-y-auto border-r border-zinc-800 pb-16 md:pb-0">
                   {children}
                 </main>

--- a/src/components/face/FaceActivityFeed.tsx
+++ b/src/components/face/FaceActivityFeed.tsx
@@ -1,6 +1,9 @@
+"use client";
+
 import { type Face } from "@/types/face";
 import { activityRepository } from "@/repositories/activity-repository";
 import { userRepository } from "@/repositories/user-repository";
+import { useDetailPanel } from "@/lib/detail-panel-context";
 import UIActivityCard from "@/components/ui/ActivityCard";
 
 type FaceActivityFeedProps = {
@@ -11,6 +14,8 @@ type FaceActivityFeedProps = {
  * 指定フェイスに属するアクティビティを時系列降順で表示するフィード。
  */
 const FaceActivityFeed = ({ face }: FaceActivityFeedProps) => {
+  const { openActivity } = useDetailPanel();
+
   // 該当フェイスのアクティビティを取得（Repository 経由・降順済み）
   const faceActivities = activityRepository.listByFaceId(face.id);
 
@@ -39,6 +44,7 @@ const FaceActivityFeed = ({ face }: FaceActivityFeedProps) => {
               user={user}
               faceTitle={faceTitle}
               faceId={face.id}
+              onClick={() => openActivity(activity.id)}
             />
           </li>
         );

--- a/src/components/home/ActivityCard.tsx
+++ b/src/components/home/ActivityCard.tsx
@@ -9,13 +9,15 @@ type Props = {
   user: User;
   /** true のとき最初の画像を優先読み込み（LCP 対策） */
   priority?: boolean;
+  /** クリック時のコールバック（DetailPanel 連携用） */
+  onClick?: () => void;
 };
 
 /**
  * ホーム画面用の ActivityCard。
  * ui/ActivityCard にフェイス情報を解決して渡すラッパー。
  */
-const ActivityCard = ({ activity, face, user, priority = false }: Props) => {
+const ActivityCard = ({ activity, face, user, priority = false, onClick }: Props) => {
   const faceTitle = [face.emoji, face.name].filter(Boolean).join(" ");
   return (
     <UIActivityCard
@@ -24,6 +26,7 @@ const ActivityCard = ({ activity, face, user, priority = false }: Props) => {
       faceTitle={faceTitle}
       faceId={face.id}
       priority={priority}
+      onClick={onClick}
     />
   );
 };

--- a/src/components/home/ActivityFeed.tsx
+++ b/src/components/home/ActivityFeed.tsx
@@ -1,6 +1,9 @@
+"use client";
+
 import { activityRepository } from "@/repositories/activity-repository";
 import { faceRepository } from "@/repositories/face-repository";
 import { userRepository } from "@/repositories/user-repository";
+import { useDetailPanel } from "@/lib/detail-panel-context";
 import ActivityCard from "./ActivityCard";
 
 type ActivityFeedProps = {
@@ -14,6 +17,7 @@ type ActivityFeedProps = {
  * selectedFaceId が指定されている場合は該当フェイスのみに絞り込む。
  */
 const ActivityFeed = ({ selectedFaceId }: ActivityFeedProps) => {
+  const { openActivity } = useDetailPanel();
   const user = userRepository.getCurrentUser();
 
   const allActivities = activityRepository.listByUserId(user.id);
@@ -49,6 +53,7 @@ const ActivityFeed = ({ selectedFaceId }: ActivityFeedProps) => {
               face={face}
               user={user}
               priority={index === 0}
+              onClick={() => openActivity(activity.id)}
             />
           </li>
         );

--- a/src/components/ui/ActivityCard.tsx
+++ b/src/components/ui/ActivityCard.tsx
@@ -46,6 +46,18 @@ const ActivityCard = ({
   return (
     <article
       onClick={onClick}
+      role={onClick ? "button" : undefined}
+      tabIndex={onClick ? 0 : undefined}
+      onKeyDown={
+        onClick
+          ? (e) => {
+              if (e.key === "Enter" || e.key === " ") {
+                e.preventDefault();
+                onClick();
+              }
+            }
+          : undefined
+      }
       className={cn(
         "flex flex-col gap-3 rounded-2xl bg-zinc-800/60 p-4 transition hover:bg-zinc-800 hover:scale-[1.01] active:scale-[0.99]",
         onClick && "cursor-pointer",
@@ -61,7 +73,7 @@ const ActivityCard = ({
             {user.badge && <Badge emoji={user.badge} />}
           </div>
           <div className="flex items-center gap-2">
-            <Link href={`/faces/${faceId}`}>
+            <Link href={`/faces/${faceId}`} onClick={(e) => e.stopPropagation()}>
               <FaceChip
                 title={faceTitle}
                 faceId={faceId}
@@ -87,7 +99,7 @@ const ActivityCard = ({
       {isLong && (
         <button
           type="button"
-          onClick={() => setExpanded((prev) => !prev)}
+          onClick={(e) => { e.stopPropagation(); setExpanded((prev) => !prev); }}
           className="self-start text-xs font-medium text-violet-400 hover:text-violet-300 transition-colors"
         >
           {expanded ? "折りたたむ" : "もっと見る"}

--- a/src/components/ui/ActivityCard.tsx
+++ b/src/components/ui/ActivityCard.tsx
@@ -99,7 +99,10 @@ const ActivityCard = ({
       {isLong && (
         <button
           type="button"
-          onClick={(e) => { e.stopPropagation(); setExpanded((prev) => !prev); }}
+          onClick={(e) => {
+              e.stopPropagation();
+              setExpanded((prev) => !prev);
+            }}
           className="self-start text-xs font-medium text-violet-400 hover:text-violet-300 transition-colors"
         >
           {expanded ? "折りたたむ" : "もっと見る"}

--- a/src/components/ui/ActivityCard.tsx
+++ b/src/components/ui/ActivityCard.tsx
@@ -20,6 +20,8 @@ type ActivityCardProps = {
   /** true のとき最初の画像を優先読み込み（LCP 対策） */
   priority?: boolean;
   className?: string;
+  /** クリック時のコールバック（DetailPanel 連携用） */
+  onClick?: () => void;
 };
 
 const COLLAPSE_THRESHOLD = 200;
@@ -31,6 +33,7 @@ const ActivityCard = ({
   faceId,
   priority = false,
   className,
+  onClick,
 }: ActivityCardProps) => {
   const isLong = activity.body.length > COLLAPSE_THRESHOLD;
   const [expanded, setExpanded] = useState(false);
@@ -42,8 +45,10 @@ const ActivityCard = ({
 
   return (
     <article
+      onClick={onClick}
       className={cn(
         "flex flex-col gap-3 rounded-2xl bg-zinc-800/60 p-4 transition hover:bg-zinc-800 hover:scale-[1.01] active:scale-[0.99]",
+        onClick && "cursor-pointer",
         className,
       )}
     >

--- a/src/components/ui/DetailPanel.tsx
+++ b/src/components/ui/DetailPanel.tsx
@@ -1,20 +1,21 @@
-import type { ReactNode } from "react";
+"use client";
 
-type DetailPanelProps = {
-  content?: ReactNode;
-  placeholderEmoji?: string;
-  placeholderMessage?: string;
-};
+import { useDetailPanel } from "@/lib/detail-panel-context";
+import ActivityDetail from "./ActivityDetail";
+import FaceDetail from "./FaceDetail";
 
 type DetailPanelPlaceholderProps = {
-  emoji: string;
+  emoji?: string;
   message?: string;
 };
 
 /**
  * DetailPanel 未選択時のプレースホルダー
  */
-const DetailPanelPlaceholder = ({ emoji, message }: DetailPanelPlaceholderProps) => {
+const DetailPanelPlaceholder = ({
+  emoji = "🗂️",
+  message,
+}: DetailPanelPlaceholderProps) => {
   return (
     <div className="flex flex-col items-center justify-center h-full gap-3 px-8 text-center">
       <span className="text-4xl text-zinc-700">{emoji}</span>
@@ -26,19 +27,30 @@ const DetailPanelPlaceholder = ({ emoji, message }: DetailPanelPlaceholderProps)
 /**
  * DetailPanel（右カラム詳細パネル）
  * PC 表示時に MainColumn の右側に固定表示される。
- * 中央カラムで選択したアイテムの詳細を表示する。
- * content が渡された場合はそれを表示し、未選択時はプレースホルダーを表示する。
+ * DetailPanelContext の state に基づいて ActivityDetail / FaceDetail を表示する。
  */
-const DetailPanel = ({
-  content,
-  placeholderEmoji = "🗂️",
-  placeholderMessage,
-}: DetailPanelProps) => {
+const DetailPanel = () => {
+  const { state } = useDetailPanel();
+
+  const renderContent = () => {
+    switch (state.type) {
+      case "activity":
+        return <ActivityDetail activityId={state.activityId} />;
+      case "face":
+        return <FaceDetail faceId={state.faceId} />;
+      default:
+        return (
+          <DetailPanelPlaceholder
+            emoji="🗂️"
+            message="← 左のリストから選択してください"
+          />
+        );
+    }
+  };
+
   return (
     <aside className="hidden md:flex flex-col w-96 shrink-0 overflow-y-auto h-[calc(100vh-3rem)]">
-      {content ?? (
-        <DetailPanelPlaceholder emoji={placeholderEmoji} message={placeholderMessage} />
-      )}
+      {renderContent()}
     </aside>
   );
 };

--- a/src/components/ui/DetailPanel.tsx
+++ b/src/components/ui/DetailPanel.tsx
@@ -32,6 +32,13 @@ const DetailPanelPlaceholder = ({
 const DetailPanel = () => {
   const { state } = useDetailPanel();
 
+  const contentKey =
+    state.type === "activity"
+      ? `activity-${state.activityId}`
+      : state.type === "face"
+        ? `face-${state.faceId}`
+        : "none";
+
   const renderContent = () => {
     switch (state.type) {
       case "activity":
@@ -49,8 +56,10 @@ const DetailPanel = () => {
   };
 
   return (
-    <aside className="hidden md:flex flex-col w-96 shrink-0 overflow-y-auto h-[calc(100vh-3rem)]">
-      {renderContent()}
+    <aside className="hidden md:flex flex-col w-96 shrink-0 overflow-y-auto">
+      <div key={contentKey} className="flex flex-col flex-1">
+        {renderContent()}
+      </div>
     </aside>
   );
 };

--- a/src/components/ui/FaceDetail.tsx
+++ b/src/components/ui/FaceDetail.tsx
@@ -1,0 +1,105 @@
+"use client";
+
+import { X } from "lucide-react";
+import { faceRepository } from "@/repositories/face-repository";
+import { activityRepository } from "@/repositories/activity-repository";
+import { userRepository } from "@/repositories/user-repository";
+import { useDetailPanel } from "@/lib/detail-panel-context";
+import FaceHeader from "@/components/face/FaceHeader";
+import ActivityCard from "./ActivityCard";
+
+type FaceDetailProps = {
+  faceId: string;
+};
+
+const FaceDetail = ({ faceId }: FaceDetailProps) => {
+  const { close, openActivity } = useDetailPanel();
+
+  const face = faceRepository.findById(faceId);
+  const currentUser = userRepository.getCurrentUser();
+
+  if (!face) {
+    return (
+      <div className="flex flex-col h-full">
+        <div className="sticky top-0 flex items-center justify-between border-b border-zinc-800 bg-zinc-950/80 px-4 py-3 backdrop-blur-sm">
+          <h2 className="text-sm font-semibold text-zinc-400">フェイス詳細</h2>
+          <button
+            type="button"
+            aria-label="閉じる"
+            onClick={close}
+            className="flex h-8 w-8 items-center justify-center rounded-full text-zinc-400 hover:bg-zinc-800 hover:text-zinc-100"
+          >
+            <X size={16} />
+          </button>
+        </div>
+        <div className="flex flex-col items-center justify-center h-full gap-3 px-8 text-center">
+          <p className="text-sm text-zinc-600">フェイスが見つかりませんでした</p>
+        </div>
+      </div>
+    );
+  }
+
+  const activities = activityRepository.listByFaceId(faceId);
+  const user = userRepository.findById(face.userId);
+  const isOwner = face.userId === currentUser.id;
+  const faceTitle = [face.emoji, face.name]
+    .filter((value): value is string => Boolean(value && value.trim()))
+    .join(" ")
+    .trim() || face.name;
+
+  return (
+    <div className="flex flex-col h-full overflow-y-auto">
+      {/* ヘッダー */}
+      <div className="sticky top-0 flex items-center justify-between border-b border-zinc-800 bg-zinc-950/80 px-4 py-3 backdrop-blur-sm">
+        <h2 className="text-sm font-semibold text-zinc-400">フェイス詳細</h2>
+        <button
+          type="button"
+          aria-label="閉じる"
+          onClick={close}
+          className="flex h-8 w-8 items-center justify-center rounded-full text-zinc-400 hover:bg-zinc-800 hover:text-zinc-100"
+        >
+          <X size={16} />
+        </button>
+      </div>
+
+      {/* FaceHeader（既存コンポーネントを流用） */}
+      <FaceHeader face={face} isOwner={isOwner} />
+
+      {/* 区切り */}
+      <div className="border-b border-zinc-800" />
+
+      {/* アクティビティ一覧 */}
+      <div className="px-4 py-4 flex flex-col gap-3">
+        <p className="text-xs font-semibold uppercase tracking-wider text-zinc-500">
+          このフェイスのアクティビティ
+        </p>
+        {activities.length === 0 ? (
+          <p className="text-sm text-zinc-600">まだアクティビティがありません</p>
+        ) : (
+          activities.map((activity, i) => {
+            const activityUser = userRepository.findById(activity.userId) ?? user;
+            if (!activityUser) return null;
+
+            return (
+              <div
+                key={activity.id}
+                className="cursor-pointer"
+                onClick={() => openActivity(activity.id)}
+              >
+                <ActivityCard
+                  activity={activity}
+                  user={activityUser}
+                  faceTitle={faceTitle}
+                  faceId={faceId}
+                  priority={i === 0}
+                />
+              </div>
+            );
+          })
+        )}
+      </div>
+    </div>
+  );
+};
+
+export default FaceDetail;

--- a/src/components/ui/FaceDetail.tsx
+++ b/src/components/ui/FaceDetail.tsx
@@ -1,5 +1,6 @@
 "use client";
 
+import { useMemo } from "react";
 import { X } from "lucide-react";
 import { faceRepository } from "@/repositories/face-repository";
 import { activityRepository } from "@/repositories/activity-repository";
@@ -17,6 +18,10 @@ const FaceDetail = ({ faceId }: FaceDetailProps) => {
 
   const face = faceRepository.findById(faceId);
   const currentUser = userRepository.getCurrentUser();
+  const userMap = useMemo(
+    () => new Map(userRepository.listAll().map((u) => [u.id, u])),
+    [],
+  );
 
   if (!face) {
     return (
@@ -41,7 +46,6 @@ const FaceDetail = ({ faceId }: FaceDetailProps) => {
 
   const activities = activityRepository.listByFaceId(faceId);
   const user = userRepository.findById(face.userId);
-  const userMap = new Map(userRepository.listAll().map((u) => [u.id, u]));
   const isOwner = face.userId === currentUser.id;
   const faceTitle = [face.emoji, face.name]
     .filter((value): value is string => Boolean(value && value.trim()))

--- a/src/components/ui/FaceDetail.tsx
+++ b/src/components/ui/FaceDetail.tsx
@@ -41,6 +41,7 @@ const FaceDetail = ({ faceId }: FaceDetailProps) => {
 
   const activities = activityRepository.listByFaceId(faceId);
   const user = userRepository.findById(face.userId);
+  const userMap = new Map(userRepository.listAll().map((u) => [u.id, u]));
   const isOwner = face.userId === currentUser.id;
   const faceTitle = [face.emoji, face.name]
     .filter((value): value is string => Boolean(value && value.trim()))
@@ -77,7 +78,7 @@ const FaceDetail = ({ faceId }: FaceDetailProps) => {
           <p className="text-sm text-zinc-600">まだアクティビティがありません</p>
         ) : (
           activities.map((activity, i) => {
-            const activityUser = userRepository.findById(activity.userId) ?? user;
+            const activityUser = userMap.get(activity.userId) ?? user;
             if (!activityUser) return null;
 
             return (

--- a/src/components/ui/FaceDetail.tsx
+++ b/src/components/ui/FaceDetail.tsx
@@ -81,19 +81,15 @@ const FaceDetail = ({ faceId }: FaceDetailProps) => {
             if (!activityUser) return null;
 
             return (
-              <div
+              <ActivityCard
                 key={activity.id}
-                className="cursor-pointer"
+                activity={activity}
+                user={activityUser}
+                faceTitle={faceTitle}
+                faceId={faceId}
+                priority={i === 0}
                 onClick={() => openActivity(activity.id)}
-              >
-                <ActivityCard
-                  activity={activity}
-                  user={activityUser}
-                  faceTitle={faceTitle}
-                  faceId={faceId}
-                  priority={i === 0}
-                />
-              </div>
+              />
             );
           })
         )}

--- a/src/components/ui/SideNav.tsx
+++ b/src/components/ui/SideNav.tsx
@@ -9,6 +9,7 @@ import FaceNavItem from "@/components/ui/FaceNavItem";
 import CreateFaceModal from "@/components/face/CreateFaceModal";
 import { faceRepository } from "@/repositories/face-repository";
 import { userRepository } from "@/repositories/user-repository";
+import { useDetailPanel } from "@/lib/detail-panel-context";
 import type { Face } from "@/types/face";
 
 type NavItem = {
@@ -31,6 +32,7 @@ const SideNav = () => {
 
   const currentUser = userRepository.getCurrentUser();
   const faces = faceRepository.listByUserId(currentUser.id);
+  const { openFace } = useDetailPanel();
 
   // パス名からアクティブなフェイスIDを導出
   const activeFaceId = pathname.startsWith("/faces/")
@@ -46,6 +48,7 @@ const SideNav = () => {
 
   const handleFaceNavItemClick = (face: Face) => {
     router.push(`/faces/${face.id}`);
+    openFace(face.id);
   };
 
   return (

--- a/src/components/ui/SideNav.tsx
+++ b/src/components/ui/SideNav.tsx
@@ -2,14 +2,13 @@
 
 import { useState } from "react";
 import Link from "next/link";
-import { usePathname } from "next/navigation";
+import { usePathname, useRouter } from "next/navigation";
 import { Home, Bell, Search, Rss, Plus, type LucideIcon } from "lucide-react";
 import { cn } from "@/lib/utils";
 import FaceNavItem from "@/components/ui/FaceNavItem";
 import CreateFaceModal from "@/components/face/CreateFaceModal";
 import { faceRepository } from "@/repositories/face-repository";
 import { userRepository } from "@/repositories/user-repository";
-import { useDetailPanel } from "@/lib/detail-panel-context";
 import type { Face } from "@/types/face";
 
 type NavItem = {
@@ -27,13 +26,16 @@ const NAV_ITEMS: NavItem[] = [
 
 const SideNav = () => {
   const pathname = usePathname();
+  const router = useRouter();
   const [isCreateModalOpen, setIsCreateModalOpen] = useState(false);
-  const { openFace, state } = useDetailPanel();
 
   const currentUser = userRepository.getCurrentUser();
   const faces = faceRepository.listByUserId(currentUser.id);
 
-  const activeFaceId = state.type === "face" ? state.faceId : undefined;
+  // パス名からアクティブなフェイスIDを導出
+  const activeFaceId = pathname.startsWith("/faces/")
+    ? pathname.split("/")[2]
+    : undefined;
 
   const handleOpenCreateModal = () => setIsCreateModalOpen(true);
   const handleCloseCreateModal = () => setIsCreateModalOpen(false);
@@ -43,7 +45,7 @@ const SideNav = () => {
   };
 
   const handleFaceNavItemClick = (face: Face) => {
-    openFace(face.id);
+    router.push(`/faces/${face.id}`);
   };
 
   return (

--- a/src/components/ui/SideNav.tsx
+++ b/src/components/ui/SideNav.tsx
@@ -9,6 +9,7 @@ import FaceNavItem from "@/components/ui/FaceNavItem";
 import CreateFaceModal from "@/components/face/CreateFaceModal";
 import { faceRepository } from "@/repositories/face-repository";
 import { userRepository } from "@/repositories/user-repository";
+import { useDetailPanel } from "@/lib/detail-panel-context";
 import type { Face } from "@/types/face";
 
 type NavItem = {
@@ -27,9 +28,12 @@ const NAV_ITEMS: NavItem[] = [
 const SideNav = () => {
   const pathname = usePathname();
   const [isCreateModalOpen, setIsCreateModalOpen] = useState(false);
+  const { openFace, state } = useDetailPanel();
 
   const currentUser = userRepository.getCurrentUser();
   const faces = faceRepository.listByUserId(currentUser.id);
+
+  const activeFaceId = state.type === "face" ? state.faceId : undefined;
 
   const handleOpenCreateModal = () => setIsCreateModalOpen(true);
   const handleCloseCreateModal = () => setIsCreateModalOpen(false);
@@ -38,9 +42,8 @@ const SideNav = () => {
     setIsCreateModalOpen(false);
   };
 
-  // TODO: Issue #79/#80 で DetailPanel との連携を追加する
-  const handleFaceNavItemClick = (_face: Face) => {
-    // DetailPanel にフェイス詳細を表示（未実装）
+  const handleFaceNavItemClick = (face: Face) => {
+    openFace(face.id);
   };
 
   return (
@@ -102,6 +105,7 @@ const SideNav = () => {
             <FaceNavItem
               key={face.id}
               face={face}
+              activeFaceId={activeFaceId}
               onClick={handleFaceNavItemClick}
             />
           ))}


### PR DESCRIPTION
## 概要

DetailPanelに表示するフェイス詳細ビュー `FaceDetail` コンポーネントを新規作成した。
SideNavの `FaceNavItem` クリックおよび検索画面のフェイス行クリック時に DetailPanel へ表示されることを想定した実装。

## 関連Issue

Closes #82

## 変更点

### `src/components/ui/FaceDetail.tsx`（新規作成）

- `faceId: string` を受け取る新規コンポーネント
- スティッキーヘッダーに "フェイス詳細" ラベルと閉じるボタン（`ActivityDetail` と統一したデザイン）を配置
- `faceRepository.findById(faceId)` / `activityRepository.listByFaceId(faceId)` / `userRepository.getCurrentUser()` / `userRepository.findById(face.userId)` でデータを取得
- `FaceHeader`（既存コンポーネント）を流用し、オーナー判定（`face.userId === currentUser.id`）を渡す
- 区切り線の下にアクティビティ一覧を表示
- 各 `ActivityCard` を `div[onClick]` でラップし、クリック時に `useDetailPanel().openActivity(activity.id)` を呼び出してDetailPanelをActivityDetailに切り替え
- フェイス未発見・アクティビティ0件のエラー/空状態に対応

## 動作確認

- [x] TypeScriptエラーなし（`get_errors` で確認済み）
- [x] ESLintエラーなし（`npm run lint` で確認済み）
- [x] フェイス詳細が DetailPanel に表示される
- [x] アクティビティカードをクリックすると ActivityDetail に切り替わる
- [x] 閉じるボタンで DetailPanel が閉じる
- [x] フェイスが見つからない場合にエラー状態が表示される
