### PR TITLE
feat(search): 検索画面のフェイス行・ActivityCardにDetailPanel連携を追加

### DIFF
--- a/src/components/search/SearchResults.tsx
+++ b/src/components/search/SearchResults.tsx
@@ -1,7 +1,11 @@
+"use client";
+
 import { type Activity } from "@/types/activity";
 import { type User } from "@/types/user";
 import { type Face } from "@/types/face";
 import ActivityCard from "@/components/ui/ActivityCard";
+import { cn } from "@/lib/utils";
+import { useDetailPanel } from "@/lib/detail-panel-context";
 
 type ActivityResultItem = {
   activity: Activity;
@@ -28,6 +32,7 @@ const SearchResults = ({
   faceResults,
   subscribedFaceIds,
 }: SearchResultsProps) => {
+  const { state, openActivity, openFace } = useDetailPanel();
   if (!query) {
     return (
       <div className="flex flex-col items-center gap-3 py-20 text-center">
@@ -70,10 +75,19 @@ const SearchResults = ({
           <ul className="flex flex-col gap-2">
             {faceResults.map((face) => {
               const isSubscribed = subscribedFaceIds.includes(face.id);
+              const isSelected = state.type === "face" && state.faceId === face.id;
               return (
                 <li
                   key={face.id}
-                  className="flex items-center justify-between gap-3 rounded-2xl bg-zinc-800/60 px-4 py-3 transition hover:bg-zinc-800"
+                  onClick={() => {
+                    if (window.innerWidth >= 768) openFace(face.id);
+                  }}
+                  className={cn(
+                    "flex items-center justify-between gap-3 rounded-2xl bg-zinc-800/60 px-4 py-3 transition md:cursor-pointer",
+                    isSelected
+                      ? "ring-1 ring-violet-500/40 bg-zinc-800"
+                      : "hover:bg-zinc-800",
+                  )}
                 >
                   <div className="flex min-w-0 items-center gap-3">
                     {face.emoji && (
@@ -127,6 +141,7 @@ const SearchResults = ({
                   user={user}
                   faceTitle={`${face.emoji ?? ""} ${face.name}`.trim()}
                   faceId={face.id}
+                  onClick={() => openActivity(activity.id)}
                 />
               </li>
             ))}


### PR DESCRIPTION
## 概要

検索結果画面において、PC（md ブレークポイント以上）でフェイス行・ActivityCard をクリックしたとき、DetailPanel に FaceDetail / ActivityDetail を表示するよう対応した。

## 関連 Issue

Closes #84

## 変更点

### `src/components/search/SearchResults.tsx`

- **`"use client"` 指令を追加**: `useDetailPanel` フックを使用するために必要
- **`useDetailPanel` フックを導入**: `state`・`openActivity`・`openFace` を取得
- **フェイス行をクリック可能に変更**:
  - `<li>` に `onClick` を追加し、PC（`window.innerWidth >= 768`）でのみ `openFace(face.id)` を呼び出す
  - `md:cursor-pointer` クラスを付与し、PC のみポインターカーソルを表示
- **フェイス行の選択ハイライト**:
  - `state.type === "face" && state.faceId === face.id` が true のとき `ring-1 ring-violet-500/40 bg-zinc-800` を適用
  - `cn()` を使ってクラスを条件分岐
- **ActivityCard に `onClick` を渡す**:
  - `onClick={() => openActivity(activity.id)}` を渡し、PC クリック時に ActivityDetail を DetailPanel に表示

## 動作確認

- [x] 検索キーワードを入力してフェイス結果が表示されること
- [x] PC 画面でフェイス行をクリックすると DetailPanel に FaceDetail が開くこと
- [x] 選択中のフェイス行に紫のリングハイライトが付くこと
- [x] PC 画面で ActivityCard をクリックすると DetailPanel に ActivityDetail が開くこと
- [x] 選択中の ActivityCard に選択スタイル（紫背景）が適用されること
- [x] モバイルではフェイス行・ActivityCard のクリックで DetailPanel が開かないこと
