### PR TITLE
feat(notifications): 通知アイテムに DetailPanel 連携を追加

### DIFF
--- a/src/components/notifications/NotificationList.tsx
+++ b/src/components/notifications/NotificationList.tsx
@@ -1,3 +1,5 @@
+"use client";
+
 import Avatar from "@/components/ui/Avatar";
 import { notificationRepository } from "@/repositories/notification-repository";
 import { userRepository } from "@/repositories/user-repository";
@@ -6,6 +8,8 @@ import { activityRepository } from "@/repositories/activity-repository";
 import { type Notification } from "@/types/notification";
 import { type User } from "@/types/user";
 import { formatRelativeTime } from "@/lib/format-relative-time";
+import { cn } from "@/lib/utils";
+import { useDetailPanel } from "@/lib/detail-panel-context";
 
 // ─── 通知アイテム ──────────────────────────────────────────────
 
@@ -15,6 +19,8 @@ type NotificationItemProps = {
   detail: string;
   /** リンク通知の場合のアクティビティ本文スニペット（任意） */
   activitySnippet?: string;
+  /** リンク通知の場合の紐づくアクティビティID */
+  activityId?: string;
 };
 
 const NotificationItem = ({
@@ -22,11 +28,27 @@ const NotificationItem = ({
   fromUser,
   detail,
   activitySnippet,
+  activityId,
 }: NotificationItemProps) => {
+  const { openActivity, state } = useDetailPanel();
   const isLink = notification.type === "link";
 
+  const isSelected =
+    state.type === "activity" && activityId !== undefined && state.activityId === activityId;
+
+  const handleClick = () => {
+    if (activityId) openActivity(activityId);
+  };
+
   return (
-    <li className="flex gap-3 rounded-2xl bg-zinc-800/60 p-4 transition hover:bg-zinc-800">
+    <li
+      onClick={handleClick}
+      className={cn(
+        "flex gap-3 rounded-2xl bg-zinc-800/60 p-4 transition",
+        activityId && "md:cursor-pointer hover:bg-zinc-800",
+        isSelected && "ring-1 ring-violet-500/40 bg-zinc-800",
+      )}
+    >
       {/* アバター */}
       <div className="shrink-0">
         <Avatar src={fromUser.avatarUrl} alt={fromUser.name} size="md" />
@@ -65,8 +87,9 @@ const NotificationItem = ({
 // ─── NotificationList ──────────────────────────────────────────
 
 /**
- * 通知一覧コンポーネント（Server Component）。
+ * 通知一覧コンポーネント（Client Component）。
  * notificationRepository から全通知を取得し、時系列降順で表示する。
+ * リンク通知のアイテムをクリックすると DetailPanel に紐づくアクティビティを表示する。
  */
 const NotificationList = () => {
   const notifications = notificationRepository.listAll();
@@ -104,6 +127,7 @@ const NotificationList = () => {
               fromUser={fromUser}
               detail={detail}
               activitySnippet={activity?.body}
+              activityId={notification.activityId}
             />
           );
         }


### PR DESCRIPTION
## 概要

通知画面の NotificationItem を PC でクリックしたとき、DetailPanel に紐づくアクティビティの詳細を表示するように対応した。

## 関連 Issue

Closes #85

## 変更点

### `src/components/notifications/NotificationList.tsx`

- `"use client"` ディレクティブを追加し、Client Component に変更
- `cn`（`@/lib/utils`）および `useDetailPanel`（`@/lib/detail-panel-context`）を import
- `NotificationItemProps` に `activityId?: string` フィールドを追加
- `NotificationItem` で `useDetailPanel()` を呼び出し、`openActivity` / `state` を取得
- `<li>` に `onClick={handleClick}` を追加し、`activityId` が存在するときのみ `openActivity(activityId)` を呼び出す
- 選択状態（`isSelected`）を `state.type === "activity" && state.activityId === activityId` で判定し、選択中は `ring-1 ring-violet-500/40 bg-zinc-800` を適用
- `link` 通知の `NotificationItem` に `activityId={notification.activityId}` を渡すよう更新
- クラスメントを "Server Component" → "Client Component" に更新

### 変更なし

- `src/types/notification.ts` — `link` 型に既に `activityId: string` が存在するため変更不要
- `src/mocks/notifications.ts` — 既に全 `link` 通知に `activityId` が設定済みのため変更不要

## 動作確認

- [x] PC（md ブレークポイント以上）で通知画面を開く
- [x] 「🔗 リンク」バッジの通知アイテムをクリックすると DetailPanel にアクティビティ詳細が表示される
- [x] 選択中の通知アイテムに紫のリングが表示される
- [x] 「📥 サブスク」バッジの通知アイテムはクリックしても何も起こらない（`activityId` なし）
- [x] 別のリンク通知をクリックすると選択が切り替わる
