### PR TITLE
feat(subscriptions): サブスク画面にDetailPanel連携とフェイスリンクを追加

### DIFF
--- a/src/components/subscriptions/SubscriptionFeed.tsx
+++ b/src/components/subscriptions/SubscriptionFeed.tsx
@@ -1,9 +1,12 @@
+"use client";
+
 import Link from "next/link";
 import { activityRepository } from "@/repositories/activity-repository";
 import { faceRepository } from "@/repositories/face-repository";
 import { userRepository } from "@/repositories/user-repository";
 import { subscriptionRepository } from "@/repositories/subscription-repository";
 import ActivityCard from "@/components/ui/ActivityCard";
+import { useDetailPanel } from "@/lib/detail-panel-context";
 
 /**
  * サブスク画面フィード。
@@ -13,6 +16,8 @@ import ActivityCard from "@/components/ui/ActivityCard";
  * 各カードには「誰の・何のフェイスの投稿か」を明示する。
  */
 const SubscriptionFeed = () => {
+  const { openActivity } = useDetailPanel();
+
   // サブスクライブ中フェイスID一覧をリポジトリ経由で取得
   const subscribedFaceIds = subscriptionRepository.getSubscribedFaceIds();
 
@@ -61,6 +66,7 @@ const SubscriptionFeed = () => {
               user={user}
               faceTitle={`${face.emoji ?? ""} ${face.name}`.trim()}
               faceId={face.id}
+              onClick={() => openActivity(activity.id)}
             />
           </li>
         );

--- a/src/components/ui/ActivityDetail.tsx
+++ b/src/components/ui/ActivityDetail.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import Image from "next/image";
+import Link from "next/link";
 import { X } from "lucide-react";
 import { activityRepository } from "@/repositories/activity-repository";
 import { faceRepository } from "@/repositories/face-repository";
@@ -111,6 +112,14 @@ const ActivityDetail = ({ activityId }: ActivityDetailProps) => {
             ))}
           </div>
         )}
+
+        {/* フェイスへのリンク */}
+        <Link
+          href={`/faces/${activity.faceId}`}
+          className="mt-2 self-start text-xs text-violet-400 hover:text-violet-300 transition-colors"
+        >
+          → このフェイスを見る
+        </Link>
       </div>
     </div>
   );


### PR DESCRIPTION
## 概要

サブスク画面の ActivityCard を PC でクリックしたとき、DetailPanel にアクティビティ詳細を表示するよう対応した。
また ActivityDetail の下部に「このフェイスを見る」リンクを追加し、フェイスページへの導線を設けた。

## 関連Issue

Closes #86

## 変更点

### `src/components/subscriptions/SubscriptionFeed.tsx`

- `"use client"` ディレクティブを追加（`useDetailPanel` hook 使用のため Server Component から Client Component に変更）
- `useDetailPanel` から `openActivity` を取得し、各 `ActivityCard` の `onClick` に渡すよう追加
- PC 幅（\`md:\`）でカードをクリックすると DetailPanel にアクティビティ詳細が表示される

### `src/components/ui/ActivityDetail.tsx`

- `Link`（next/link）をインポート
- コンテンツ下部に「→ このフェイスを見る」リンクを追加
  - リンク先: `/faces/${activity.faceId}`
  - 常時表示（サブスク画面に限らず全コンテキストで表示）

## 動作確認

- [x] サブスク画面（`/subscriptions`）で PC 幅にし、ActivityCard をクリックすると DetailPanel が開く
- [x] 選択された ActivityCard がハイライト（紫背景）される
- [x] DetailPanel 内の ActivityDetail 下部に「→ このフェイスを見る」リンクが表示される
- [x] リンクをクリックすると該当フェイスページ（`/faces/:faceId`）に遷移する
- [x] ホーム画面・検索画面の DetailPanel 動作に影響がないこと
