### PR TITLE
feat(ui): Midnight Ink デザインシステム全面実装 + ContextRail実データ化・FaceActivityFeedソート（#99-#113）

### DIFF
--- a/src/app/faces/[faceId]/page.tsx
+++ b/src/app/faces/[faceId]/page.tsx
@@ -23,45 +23,68 @@ const FaceDetailPage = async ({ params }: Props) => {
   return (
     <div className="flex flex-col">
       {/* スティッキーヘッダー */}
-      <header className="sticky top-0 z-10 flex items-center gap-2 border-b border-zinc-800 bg-zinc-950/80 px-4 py-3 backdrop-blur-sm">
+      <header
+        className="sticky top-0 z-10 flex items-center gap-3"
+        style={{
+          height: 52,
+          padding: "0 18px",
+          background: "var(--mf-bg-light)",
+          borderBottom: "0.5px solid var(--mf-line)",
+        }}
+      >
         <Link
           href="/faces"
-          className="flex items-center justify-center rounded-full p-1 text-zinc-400 transition-colors hover:bg-zinc-800 hover:text-zinc-100"
+          style={{
+            width: 34,
+            height: 34,
+            borderRadius: "50%",
+            display: "flex",
+            alignItems: "center",
+            justifyContent: "center",
+            color: "var(--mf-brand)",
+            textDecoration: "none",
+          }}
           aria-label="フェイス一覧に戻る"
         >
-          {/* 左矢印アイコン */}
           <svg
-            xmlns="http://www.w3.org/2000/svg"
-            width="20"
-            height="20"
+            width={20}
+            height={20}
             viewBox="0 0 24 24"
             fill="none"
             stroke="currentColor"
-            strokeWidth="2"
+            strokeWidth={2}
             strokeLinecap="round"
             strokeLinejoin="round"
           >
             <path d="M15 18l-6-6 6-6" />
           </svg>
         </Link>
-        <h2 className="truncate text-base font-bold text-zinc-100">
+        <h2
+          style={{
+            flex: 1,
+            overflow: "hidden",
+            textOverflow: "ellipsis",
+            whiteSpace: "nowrap",
+            fontSize: 16,
+            fontWeight: 700,
+            color: "var(--mf-brand)",
+            margin: 0,
+          }}
+        >
           {face.emoji ? `${face.emoji} ${face.name}` : face.name}
         </h2>
       </header>
 
       <main>
-        {/* フェイスヘッダー（絵文字・名前・説明・サブスクボタン） */}
-        <div className="border-b border-zinc-800">
+        <div style={{ borderBottom: "0.5px solid var(--mf-line)" }}>
           <FaceHeader face={face} isOwner={face.userId === currentUser.id} />
         </div>
 
-        {/* アクティビティ一覧 */}
-        <section className="px-4 py-4">
+        <section>
           <FaceActivityFeed face={face} />
         </section>
       </main>
 
-      {/* 自分のフェイスのみ投稿FABを表示 */}
       {face.userId === currentUser.id && (
         <FAB defaultFaceId={face.id} />
       )}

--- a/src/app/faces/[faceId]/page.tsx
+++ b/src/app/faces/[faceId]/page.tsx
@@ -2,8 +2,7 @@ import { notFound } from "next/navigation";
 import Link from "next/link";
 import { faceRepository } from "@/repositories/face-repository";
 import { userRepository } from "@/repositories/user-repository";
-import FaceHeader from "@/components/face/FaceHeader";
-import FaceActivityFeed from "@/components/face/FaceActivityFeed";
+import FaceDetailClient from "@/components/face/FaceDetailClient";
 import FAB from "@/components/ui/FAB";
 
 type Props = {
@@ -76,13 +75,10 @@ const FaceDetailPage = async ({ params }: Props) => {
       </header>
 
       <main>
-        <div style={{ borderBottom: "0.5px solid var(--mf-line)" }}>
-          <FaceHeader face={face} isOwner={face.userId === currentUser.id} />
-        </div>
-
-        <section>
-          <FaceActivityFeed face={face} />
-        </section>
+        <FaceDetailClient
+          face={face}
+          isOwner={face.userId === currentUser.id}
+        />
       </main>
 
       {face.userId === currentUser.id && (

--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -1,51 +1,83 @@
+@import url('https://fonts.googleapis.com/css2?family=Noto+Sans+JP:wght@300;400;500;600;700;800&family=Shippori+Mincho+B1:wght@500;600;700&family=Cormorant+Garamond:ital,wght@0,500;0,600;1,500;1,600&display=swap');
 @import "tailwindcss";
 
 :root {
-  --background: #ffffff;
-  --foreground: #171717;
+  /* Midnight Ink — brand palette */
+  --mf-brand: #1E2A4A;
+  --mf-brand-soft: #2A3960;
+  --mf-bg-light: #F8F6F1;
+  --mf-bg-paper: #F2EFE7;
+  --mf-bg-dark: #141824;
+  --mf-accent: #D4922A;
+  --mf-accent-soft: #E8B461;
+  --mf-text: #1A1A2E;
+  --mf-text-sub: rgba(26, 26, 46, 0.6);
+  --mf-text-muted: rgba(26, 26, 46, 0.42);
+  --mf-text-faint: rgba(26, 26, 46, 0.22);
+  --mf-ink: rgba(26, 26, 46, 0.92);
+  --mf-line: rgba(30, 42, 74, 0.10);
+  --mf-line-soft: rgba(30, 42, 74, 0.06);
+  --mf-surface: #FFFFFF;
+  --mf-surface-card: #FCFAF5;
+  --mf-surface-tint: #EEEAE0;
+  --mf-hover: rgba(30, 42, 74, 0.04);
+
+  /* Typography */
+  --mf-font-sans: "Noto Sans JP", "Hiragino Sans", -apple-system, "Helvetica Neue", system-ui, sans-serif;
+  --mf-font-serif: "Shippori Mincho B1", "Noto Serif JP", "Hiragino Mincho ProN", serif;
+  --mf-font-serif-en: "Cormorant Garamond", "Shippori Mincho B1", serif;
+
+  /* Face colors */
+  --mf-face-water: #5B8DB8;
+  --mf-face-moss: #5B9B72;
+  --mf-face-wisteria: #7B6B9E;
+  --mf-face-persimmon: #C47A50;
+  --mf-face-rose: #B06B7A;
+  --mf-face-grass: #A89050;
 }
 
 @theme inline {
-  --color-background: var(--background);
-  --color-foreground: var(--foreground);
-  --font-sans: var(--font-geist-sans);
-  --font-mono: var(--font-geist-mono);
-}
-
-@media (prefers-color-scheme: dark) {
-  :root {
-    --background: #000000;
-    --foreground: #ededed;
-  }
+  --color-background: var(--mf-bg-light);
+  --color-foreground: var(--mf-text);
+  --font-sans: var(--mf-font-sans);
 }
 
 body {
-  background: var(--background);
-  color: var(--foreground);
-  font-family: Arial, Helvetica, sans-serif;
+  background: var(--mf-bg-light);
+  color: var(--mf-text);
+  font-family: var(--mf-font-sans);
+  -webkit-font-smoothing: antialiased;
 }
 
-/* スクロールバーを細く・控えめに */
+/* スクロールバー非表示（.mf-scroll クラス） */
+.mf-scroll::-webkit-scrollbar {
+  display: none;
+}
+.mf-scroll {
+  scrollbar-width: none;
+}
+
+/* カーソル点滅アニメーション */
+@keyframes mf-blink {
+  50% { opacity: 0; }
+}
+
+/* カスタムスクロールバー（細め・控えめ） */
 ::-webkit-scrollbar {
   width: 4px;
 }
-
 ::-webkit-scrollbar-track {
   background: transparent;
 }
-
 ::-webkit-scrollbar-thumb {
-  background: #27272a; /* zinc-800 */
+  background: var(--mf-line);
   border-radius: 9999px;
   transition: background 0.2s;
 }
-
 ::-webkit-scrollbar-thumb:hover {
-  background: #3f3f46; /* zinc-700 */
+  background: var(--mf-text-faint);
 }
-
-/* Firefox */
 * {
   scrollbar-width: thin;
-  scrollbar-color: #27272a transparent;
+  scrollbar-color: var(--mf-line) transparent;
 }

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -3,6 +3,7 @@ import "./globals.css";
 import BottomNav from "@/components/ui/BottomNav";
 import SideNav from "@/components/ui/SideNav";
 import TopBar from "@/components/ui/TopBar";
+import AppHeader from "@/components/ui/AppHeader";
 import ContextRail from "@/components/ui/ContextRail";
 import { DetailPanelProvider } from "@/lib/detail-panel-context";
 
@@ -31,6 +32,7 @@ export default function RootLayout({
           <div className="flex h-screen w-full overflow-hidden">
             <SideNav />
             <div className="flex flex-col flex-1 min-w-0 overflow-hidden">
+              <AppHeader />
               <TopBar />
               <div className="flex flex-1 min-h-0 overflow-hidden">
                 <main

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -1,16 +1,10 @@
 import type { Metadata } from "next";
-import { Geist } from "next/font/google";
 import "./globals.css";
 import BottomNav from "@/components/ui/BottomNav";
 import SideNav from "@/components/ui/SideNav";
 import TopBar from "@/components/ui/TopBar";
-import DetailPanel from "@/components/ui/DetailPanel";
+import ContextRail from "@/components/ui/ContextRail";
 import { DetailPanelProvider } from "@/lib/detail-panel-context";
-
-const geistSans = Geist({
-  variable: "--font-geist-sans",
-  subsets: ["latin"],
-});
 
 export const metadata: Metadata = {
   title: "MultiFace",
@@ -23,24 +17,29 @@ export default function RootLayout({
   children: React.ReactNode;
 }>) {
   return (
-    <html
-      lang="ja"
-      className={`${geistSans.variable} h-full antialiased dark scroll-smooth`}
-      data-scroll-behavior="smooth"
-    >
-      <body className="min-h-full bg-zinc-950 text-zinc-100">
-        {/* PC: SideNav（左）+ TopBar / MainColumn / DetailPanel（右）の3カラム */}
-        {/* モバイル: BottomNav + 1カラム */}
+    <html lang="ja" className="h-full" data-scroll-behavior="smooth">
+      <head>
+        <link rel="preconnect" href="https://fonts.googleapis.com" />
+        <link rel="preconnect" href="https://fonts.gstatic.com" crossOrigin="" />
+        <link
+          href="https://fonts.googleapis.com/css2?family=Noto+Sans+JP:wght@300;400;500;600;700;800&family=Shippori+Mincho+B1:wght@500;600;700&family=Cormorant+Garamond:ital,wght@0,500;0,600;1,500;1,600&display=swap"
+          rel="stylesheet"
+        />
+      </head>
+      <body className="min-h-full antialiased" style={{ background: "var(--mf-bg-light)", color: "var(--mf-text)" }}>
         <DetailPanelProvider>
           <div className="flex h-screen w-full overflow-hidden">
             <SideNav />
             <div className="flex flex-col flex-1 min-w-0 overflow-hidden">
               <TopBar />
               <div className="flex flex-1 min-h-0 overflow-hidden">
-                <main className="flex-1 min-w-0 overflow-y-auto border-r border-zinc-800 pb-16 md:pb-0">
+                <main
+                  className="flex-1 min-w-0 overflow-y-auto pb-16 md:pb-0"
+                  style={{ borderRight: "0.5px solid var(--mf-line)" }}
+                >
                   {children}
                 </main>
-                <DetailPanel />
+                <ContextRail />
               </div>
             </div>
           </div>

--- a/src/app/notifications/page.tsx
+++ b/src/app/notifications/page.tsx
@@ -5,18 +5,20 @@ export default function NotificationsPage() {
   const count = notificationRepository.listAll().length;
 
   return (
-    <div className="flex flex-col">
-      {/* スティッキーヘッダー */}
-      <header className="sticky top-0 z-10 border-b border-zinc-800 bg-zinc-950/80 px-4 py-3 backdrop-blur-sm">
-        <div className="flex items-center justify-between">
-          <h1 className="text-lg font-bold text-zinc-100">通知</h1>
-          {count > 0 && (
-            <span className="text-xs text-zinc-500">{count} 件</span>
-          )}
-        </div>
-      </header>
-
-      <main className="px-4 py-4">
+    <div style={{ display: "flex", flexDirection: "column" }}>
+      <main style={{ padding: "20px 28px 32px" }}>
+        {count > 0 && (
+          <p
+            style={{
+              fontSize: 11.5,
+              color: "var(--mf-text-muted)",
+              marginBottom: 14,
+              fontWeight: 600,
+            }}
+          >
+            {count} 件の通知
+          </p>
+        )}
         <NotificationList />
       </main>
     </div>

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -4,20 +4,11 @@ import FAB from "@/components/ui/FAB";
 
 export default function Home() {
   return (
-    <div className="flex flex-col">
-      {/* スティッキーヘッダー */}
-      <header className="sticky top-0 z-10 border-b border-zinc-800 bg-zinc-950/80 px-4 py-3 backdrop-blur-sm">
-        <h1 className="text-lg font-bold text-zinc-100">ホーム</h1>
-      </header>
-
+    <div style={{ display: "flex", flexDirection: "column" }}>
       <main>
-        {/* 上部: プロフィールエリア（Server Component） */}
         <HomeProfile />
-
-        {/* 中部〜下部: フェイスフィルタ + アクティビティフィード（Client Component） */}
         <HomeClient />
       </main>
-
       <FAB />
     </div>
   );

--- a/src/app/subscriptions/page.tsx
+++ b/src/app/subscriptions/page.tsx
@@ -1,28 +1,11 @@
 import SubscriptionFeed from "@/components/subscriptions/SubscriptionFeed";
-import { subscriptionRepository } from "@/repositories/subscription-repository";
 import FAB from "@/components/ui/FAB";
 
 export default function SubscriptionsPage() {
-  const count = subscriptionRepository.getSubscribedFaceIds().length;
-
   return (
     <div style={{ display: "flex", flexDirection: "column" }}>
       <main>
-        {count > 0 && (
-          <p
-            style={{
-              padding: "14px 28px 0",
-              fontSize: 11.5,
-              color: "var(--mf-text-muted)",
-              fontWeight: 600,
-            }}
-          >
-            {count} フェイスをサブスク中
-          </p>
-        )}
-        <div style={{ padding: "0 28px" }}>
-          <SubscriptionFeed />
-        </div>
+        <SubscriptionFeed />
       </main>
       <FAB />
     </div>

--- a/src/app/subscriptions/page.tsx
+++ b/src/app/subscriptions/page.tsx
@@ -3,22 +3,27 @@ import { subscriptionRepository } from "@/repositories/subscription-repository";
 import FAB from "@/components/ui/FAB";
 
 export default function SubscriptionsPage() {
+  const count = subscriptionRepository.getSubscribedFaceIds().length;
+
   return (
-    <div className="flex flex-col">
-      {/* スティッキーヘッダー */}
-      <header className="sticky top-0 z-10 border-b border-zinc-800 bg-zinc-950/80 px-4 py-3 backdrop-blur-sm">
-        <div className="flex items-center justify-between">
-          <h1 className="text-lg font-bold text-zinc-100">サブスク</h1>
-          <span className="text-xs text-zinc-500">
-            {subscriptionRepository.getSubscribedFaceIds().length} フェイスをサブスク中
-          </span>
+    <div style={{ display: "flex", flexDirection: "column" }}>
+      <main>
+        {count > 0 && (
+          <p
+            style={{
+              padding: "14px 28px 0",
+              fontSize: 11.5,
+              color: "var(--mf-text-muted)",
+              fontWeight: 600,
+            }}
+          >
+            {count} フェイスをサブスク中
+          </p>
+        )}
+        <div style={{ padding: "0 28px" }}>
+          <SubscriptionFeed />
         </div>
-      </header>
-
-      <main className="px-4 py-4">
-        <SubscriptionFeed />
       </main>
-
       <FAB />
     </div>
   );

--- a/src/components/face/FaceActivityFeed.tsx
+++ b/src/components/face/FaceActivityFeed.tsx
@@ -2,54 +2,44 @@
 
 import { type Face } from "@/types/face";
 import { activityRepository } from "@/repositories/activity-repository";
-import { userRepository } from "@/repositories/user-repository";
 import { useDetailPanel } from "@/lib/detail-panel-context";
-import { createLookupMap, getFaceTitle } from "@/lib/display";
-import UIActivityCard from "@/components/ui/ActivityCard";
+import SeedRow from "@/components/ui/SeedRow";
 
 type FaceActivityFeedProps = {
   face: Face;
 };
 
-/**
- * 指定フェイスに属するアクティビティを時系列降順で表示するフィード。
- */
 const FaceActivityFeed = ({ face }: FaceActivityFeedProps) => {
   const { openActivity } = useDetailPanel();
-
-  // 該当フェイスのアクティビティを取得（Repository 経由・降順済み）
   const faceActivities = activityRepository.listByFaceId(face.id);
-
-  // ユーザーを O(1) で引けるようにマップ化
-  const userMap = createLookupMap(userRepository.listAll(), (user) => user.id);
-  const faceTitle = getFaceTitle(face);
 
   if (faceActivities.length === 0) {
     return (
-      <p className="py-16 text-center text-sm text-zinc-500">
-        アクティビティがありません
+      <p
+        style={{
+          textAlign: "center",
+          fontSize: 13,
+          color: "var(--mf-text-muted)",
+          padding: "64px 0",
+        }}
+      >
+        まだシードがありません
       </p>
     );
   }
 
   return (
-    <ul className="flex flex-col gap-3">
-      {faceActivities.map((activity) => {
-        const user = userMap.get(activity.userId);
-        if (!user) return null;
-        return (
-          <li key={activity.id}>
-            <UIActivityCard
-              activity={activity}
-              user={user}
-              faceTitle={faceTitle}
-              faceId={face.id}
-              onClick={() => openActivity(activity.id)}
-            />
-          </li>
-        );
-      })}
-    </ul>
+    <div style={{ padding: "0 28px" }}>
+      {faceActivities.map((activity, i) => (
+        <SeedRow
+          key={activity.id}
+          activity={activity}
+          face={face}
+          onClick={() => openActivity(activity.id)}
+          noBorder={i === faceActivities.length - 1}
+        />
+      ))}
+    </div>
   );
 };
 

--- a/src/components/face/FaceActivityFeed.tsx
+++ b/src/components/face/FaceActivityFeed.tsx
@@ -4,14 +4,24 @@ import { type Face } from "@/types/face";
 import { activityRepository } from "@/repositories/activity-repository";
 import { useDetailPanel } from "@/lib/detail-panel-context";
 import SeedRow from "@/components/ui/SeedRow";
+import type { SortOrder } from "./FaceHeader";
 
 type FaceActivityFeedProps = {
   face: Face;
+  sortOrder?: SortOrder;
 };
 
-const FaceActivityFeed = ({ face }: FaceActivityFeedProps) => {
+const FaceActivityFeed = ({ face, sortOrder = "newest" }: FaceActivityFeedProps) => {
   const { openActivity } = useDetailPanel();
-  const faceActivities = activityRepository.listByFaceId(face.id);
+
+  let faceActivities = activityRepository.listByFaceId(face.id);
+
+  if (sortOrder === "oldest") {
+    faceActivities = [...faceActivities].reverse();
+  } else if (sortOrder === "images") {
+    faceActivities = faceActivities.filter((a) => (a.imageUrls?.length ?? 0) > 0);
+  }
+  // "newest" は repository がデフォルトで降順ソート済み
 
   if (faceActivities.length === 0) {
     return (
@@ -23,7 +33,7 @@ const FaceActivityFeed = ({ face }: FaceActivityFeedProps) => {
           padding: "64px 0",
         }}
       >
-        まだシードがありません
+        {sortOrder === "images" ? "画像付きのシードがありません" : "まだシードがありません"}
       </p>
     );
   }

--- a/src/components/face/FaceDetailClient.tsx
+++ b/src/components/face/FaceDetailClient.tsx
@@ -1,0 +1,32 @@
+"use client";
+
+import { useState } from "react";
+import type { Face } from "@/types/face";
+import FaceHeader, { type SortOrder } from "./FaceHeader";
+import FaceActivityFeed from "./FaceActivityFeed";
+
+type Props = {
+  face: Face;
+  isOwner: boolean;
+};
+
+const FaceDetailClient = ({ face, isOwner }: Props) => {
+  const [sortOrder, setSortOrder] = useState<SortOrder>("newest");
+
+  return (
+    <>
+      <div style={{ borderBottom: "0.5px solid var(--mf-line)" }}>
+        <FaceHeader
+          face={face}
+          isOwner={isOwner}
+          onSortChange={setSortOrder}
+        />
+      </div>
+      <section>
+        <FaceActivityFeed face={face} sortOrder={sortOrder} />
+      </section>
+    </>
+  );
+};
+
+export default FaceDetailClient;

--- a/src/components/face/FaceHeader.tsx
+++ b/src/components/face/FaceHeader.tsx
@@ -5,14 +5,40 @@ import { useState } from "react";
 import { type Face } from "@/types/face";
 import FaceBadge from "@/components/ui/FaceBadge";
 import { getFaceTitle } from "@/lib/display";
+import { activityRepository } from "@/repositories/activity-repository";
+import { subscriptionRepository } from "@/repositories/subscription-repository";
+
+export type SortOrder = "newest" | "oldest" | "images";
 
 type FaceHeaderProps = {
   face: Face;
   isOwner?: boolean;
+  onSortChange?: (sort: SortOrder) => void;
 };
 
-const FaceHeader = ({ face, isOwner = false }: FaceHeaderProps) => {
-  const [subscribed, setSubscribed] = useState(false);
+const REFERENCE_DATE = "2026-04";
+
+const FaceHeader = ({ face, isOwner = false, onSortChange }: FaceHeaderProps) => {
+  const [subscribed, setSubscribed] = useState(() =>
+    subscriptionRepository.getSubscribedFaceIds().includes(face.id)
+  );
+  const [sort, setSort] = useState<SortOrder>("newest");
+
+  const faceActivities = activityRepository.listByFaceId(face.id);
+  const totalSeeds = faceActivities.length;
+  const monthlySeeds = faceActivities.filter((a) => a.createdAt.startsWith(REFERENCE_DATE)).length;
+  const subscriberCount = 12; // モック値
+
+  const handleSort = (s: SortOrder) => {
+    setSort(s);
+    onSortChange?.(s);
+  };
+
+  const SORT_LABELS: { key: SortOrder; label: string }[] = [
+    { key: "newest", label: "新しい順" },
+    { key: "oldest", label: "古い順" },
+    { key: "images", label: "画像あり" },
+  ];
 
   return (
     <div>
@@ -101,7 +127,7 @@ const FaceHeader = ({ face, isOwner = false }: FaceHeaderProps) => {
             flexDirection: "column",
             alignItems: "center",
             gap: 12,
-            padding: "28px 24px",
+            padding: "28px 24px 20px",
             textAlign: "center",
           }}
         >
@@ -164,6 +190,78 @@ const FaceHeader = ({ face, isOwner = false }: FaceHeaderProps) => {
           )}
         </div>
       )}
+
+      {/* 統計行 */}
+      <div
+        style={{
+          display: "flex",
+          alignItems: "center",
+          justifyContent: "center",
+          gap: 24,
+          padding: "12px 24px",
+          borderBottom: "0.5px solid var(--mf-line)",
+        }}
+      >
+        <div style={{ textAlign: "center" }}>
+          <div style={{ fontSize: 17, fontWeight: 700, color: "var(--mf-brand)" }}>
+            {totalSeeds}
+          </div>
+          <div style={{ fontSize: 10.5, color: "var(--mf-text-muted)", marginTop: 1 }}>シード</div>
+        </div>
+        <div style={{ width: 0.5, height: 28, background: "var(--mf-line)" }} />
+        <div style={{ textAlign: "center" }}>
+          <div style={{ fontSize: 17, fontWeight: 700, color: "var(--mf-brand)" }}>
+            {monthlySeeds}
+          </div>
+          <div style={{ fontSize: 10.5, color: "var(--mf-text-muted)", marginTop: 1 }}>今月</div>
+        </div>
+        {!isOwner && (
+          <>
+            <div style={{ width: 0.5, height: 28, background: "var(--mf-line)" }} />
+            <div style={{ textAlign: "center" }}>
+              <div style={{ fontSize: 17, fontWeight: 700, color: "var(--mf-brand)" }}>
+                {subscriberCount}
+              </div>
+              <div style={{ fontSize: 10.5, color: "var(--mf-text-muted)", marginTop: 1 }}>サブスク</div>
+            </div>
+          </>
+        )}
+      </div>
+
+      {/* ソートピル */}
+      <div
+        style={{
+          display: "flex",
+          alignItems: "center",
+          gap: 8,
+          padding: "10px 16px",
+          borderBottom: "0.5px solid var(--mf-line)",
+          overflowX: "auto",
+        }}
+        className="mf-scroll"
+      >
+        {SORT_LABELS.map(({ key, label }) => (
+          <button
+            key={key}
+            type="button"
+            onClick={() => handleSort(key)}
+            style={{
+              padding: "5px 14px",
+              borderRadius: 999,
+              fontSize: 12,
+              fontWeight: sort === key ? 700 : 400,
+              background: sort === key ? "var(--mf-brand)" : "var(--mf-surface-tint)",
+              color: sort === key ? "#fff" : "var(--mf-text-sub)",
+              border: "none",
+              cursor: "pointer",
+              whiteSpace: "nowrap",
+              flexShrink: 0,
+            }}
+          >
+            {label}
+          </button>
+        ))}
+      </div>
     </div>
   );
 };

--- a/src/components/face/FaceHeader.tsx
+++ b/src/components/face/FaceHeader.tsx
@@ -3,7 +3,8 @@
 import Image from "next/image";
 import { useState } from "react";
 import { type Face } from "@/types/face";
-import { cn } from "@/lib/utils";
+import FaceBadge from "@/components/ui/FaceBadge";
+import { getFaceTitle } from "@/lib/display";
 
 type FaceHeaderProps = {
   face: Face;
@@ -13,15 +14,11 @@ type FaceHeaderProps = {
 const FaceHeader = ({ face, isOwner = false }: FaceHeaderProps) => {
   const [subscribed, setSubscribed] = useState(false);
 
-  const handleSubscribe = () => {
-    setSubscribed((prev) => !prev);
-  };
-
   return (
-    <div className="flex flex-col">
+    <div>
       {face.imageUrl ? (
-        /* カバー画像あり: 画像 + グラデーションオーバーレイ */
-        <div className="relative aspect-video w-full overflow-hidden">
+        /* カバー画像あり */
+        <div style={{ position: "relative", aspectRatio: "16/9", width: "100%" }}>
           <Image
             src={face.imageUrl}
             alt={face.name}
@@ -30,36 +27,66 @@ const FaceHeader = ({ face, isOwner = false }: FaceHeaderProps) => {
             sizes="100vw"
             priority
           />
-          {/* グラデーションオーバーレイ */}
-          <div className="absolute inset-0 bg-gradient-to-t from-black/80 via-black/40 to-transparent" />
-          {/* コンテンツ（画像上に重ねる） */}
-          <div className="absolute inset-x-0 bottom-0 flex flex-col items-center gap-3 px-4 py-6 text-center">
-            {face.emoji && (
-              <span className="text-5xl leading-none" aria-hidden="true">
-                {face.emoji}
-              </span>
-            )}
-            <div className="flex items-center gap-2">
-              <h1 className="text-2xl font-bold text-white">{face.name}</h1>
+          <div
+            style={{
+              position: "absolute",
+              inset: 0,
+              background: "linear-gradient(to top, rgba(20,24,36,0.80) 0%, rgba(20,24,36,0.35) 50%, transparent 100%)",
+            }}
+          />
+          <div
+            style={{
+              position: "absolute",
+              bottom: 0,
+              left: 0,
+              right: 0,
+              padding: "24px",
+              display: "flex",
+              flexDirection: "column",
+              alignItems: "center",
+              gap: 10,
+              textAlign: "center",
+            }}
+          >
+            <FaceBadge face={face} size={56} radius={15} />
+            <div style={{ display: "flex", alignItems: "center", gap: 8 }}>
+              <h1 style={{ fontSize: 22, fontWeight: 700, color: "#fff", margin: 0 }}>
+                {getFaceTitle(face)}
+              </h1>
               {face.isPrivate && (
-                <span className="rounded-full bg-black/40 px-2 py-0.5 text-xs text-white/80">
+                <span
+                  style={{
+                    padding: "2px 8px",
+                    borderRadius: 999,
+                    background: "rgba(0,0,0,0.4)",
+                    fontSize: 11,
+                    color: "rgba(255,255,255,0.8)",
+                  }}
+                >
                   非公開
                 </span>
               )}
             </div>
             {face.description && (
-              <p className="max-w-xs text-sm text-white/80">{face.description}</p>
+              <p style={{ fontSize: 13, color: "rgba(255,255,255,0.8)", maxWidth: 320, margin: 0 }}>
+                {face.description}
+              </p>
             )}
             {!isOwner && (
               <button
                 type="button"
-                onClick={handleSubscribe}
-                className={cn(
-                  "mt-1 rounded-full px-6 py-2 text-sm font-semibold transition-colors",
-                  subscribed
-                    ? "bg-zinc-700 text-zinc-300 hover:bg-zinc-600"
-                    : "bg-violet-600 text-white hover:bg-violet-500",
-                )}
+                onClick={() => setSubscribed((prev) => !prev)}
+                style={{
+                  marginTop: 4,
+                  padding: "8px 24px",
+                  borderRadius: 999,
+                  background: subscribed ? "rgba(255,255,255,0.15)" : "var(--mf-accent)",
+                  color: "#fff",
+                  fontSize: 13,
+                  fontWeight: 700,
+                  border: "none",
+                  cursor: "pointer",
+                }}
               >
                 {subscribed ? "✓ サブスク中" : "サブスクする"}
               </button>
@@ -67,41 +94,73 @@ const FaceHeader = ({ face, isOwner = false }: FaceHeaderProps) => {
           </div>
         </div>
       ) : (
-        /* カバー画像なし: 従来どおり */
-        <div className="flex flex-col gap-4 px-4 py-6">
-          <div className="flex flex-col items-center gap-2 text-center">
-            {face.emoji && (
-              <span className="text-5xl leading-none" aria-hidden="true">
-                {face.emoji}
+        /* カバー画像なし */
+        <div
+          style={{
+            display: "flex",
+            flexDirection: "column",
+            alignItems: "center",
+            gap: 12,
+            padding: "28px 24px",
+            textAlign: "center",
+          }}
+        >
+          <FaceBadge face={face} size={56} radius={15} />
+          <div style={{ display: "flex", alignItems: "center", gap: 8 }}>
+            <h1
+              style={{
+                fontSize: 22,
+                fontWeight: 700,
+                color: "var(--mf-brand)",
+                margin: 0,
+              }}
+            >
+              {getFaceTitle(face)}
+            </h1>
+            {face.isPrivate && (
+              <span
+                style={{
+                  padding: "2px 8px",
+                  borderRadius: 999,
+                  background: "var(--mf-surface-tint)",
+                  fontSize: 11,
+                  color: "var(--mf-text-muted)",
+                }}
+              >
+                非公開
               </span>
             )}
-            <div className="flex items-center gap-2">
-              <h1 className="text-2xl font-bold text-zinc-100">{face.name}</h1>
-              {face.isPrivate && (
-                <span className="rounded-full bg-zinc-700 px-2 py-0.5 text-xs text-zinc-400">
-                  非公開
-                </span>
-              )}
-            </div>
-            {face.description && (
-              <p className="max-w-xs text-sm text-zinc-400">{face.description}</p>
-            )}
           </div>
+          {face.description && (
+            <p
+              style={{
+                fontSize: 13,
+                lineHeight: 1.7,
+                color: "var(--mf-text-sub)",
+                maxWidth: 320,
+                margin: 0,
+              }}
+            >
+              {face.description}
+            </p>
+          )}
           {!isOwner && (
-            <div className="flex justify-center">
-              <button
-                type="button"
-                onClick={handleSubscribe}
-                className={cn(
-                  "rounded-full px-6 py-2 text-sm font-semibold transition-colors",
-                  subscribed
-                    ? "bg-zinc-700 text-zinc-300 hover:bg-zinc-600"
-                    : "bg-violet-600 text-white hover:bg-violet-500",
-                )}
-              >
-                {subscribed ? "✓ サブスク中" : "サブスクする"}
-              </button>
-            </div>
+            <button
+              type="button"
+              onClick={() => setSubscribed((prev) => !prev)}
+              style={{
+                padding: "8px 24px",
+                borderRadius: 999,
+                background: subscribed ? "var(--mf-surface-tint)" : "var(--mf-accent)",
+                color: subscribed ? "var(--mf-text-sub)" : "#fff",
+                fontSize: 13,
+                fontWeight: 700,
+                border: subscribed ? "1px solid var(--mf-line)" : "none",
+                cursor: "pointer",
+              }}
+            >
+              {subscribed ? "✓ サブスク中" : "サブスクする"}
+            </button>
           )}
         </div>
       )}

--- a/src/components/face/FacesClient.tsx
+++ b/src/components/face/FacesClient.tsx
@@ -1,16 +1,17 @@
 "use client";
 
-import { useState } from "react";
-import Image from "next/image";
+import { useState, useMemo } from "react";
 import Link from "next/link";
 import type { Face } from "@/types/face";
-import FaceBadge from "@/components/ui/FaceBadge";
-import { getFaceTitle } from "@/lib/display";
+import { getFaceTitle, getFaceColor, getFaceKanji } from "@/lib/display";
+import { activityRepository } from "@/repositories/activity-repository";
 import CreateFaceModal from "./CreateFaceModal";
 
 type Props = {
   initialFaces: Face[];
 };
+
+const REFERENCE_DATE = new Date("2026-04-01");
 
 const FacesClient = ({ initialFaces }: Props) => {
   const [faces, setFaces] = useState<Face[]>(initialFaces);
@@ -19,6 +20,24 @@ const FacesClient = ({ initialFaces }: Props) => {
   const handleCreate = (newFace: Face) => {
     setFaces((prev) => [newFace, ...prev]);
   };
+
+  // フェイスごとの統計を事前計算
+  const faceStats = useMemo(() => {
+    const allActivities = activityRepository.listAll();
+    const thisMonth = REFERENCE_DATE.toISOString().slice(0, 7); // "2026-04"
+    const stats = new Map<string, { total: number; monthly: number; lastDate: string | null }>();
+    for (const face of faces) {
+      const faceActivities = allActivities.filter((a) => a.faceId === face.id);
+      const monthly = faceActivities.filter((a) => a.createdAt.startsWith(thisMonth)).length;
+      const sorted = [...faceActivities].sort((a, b) => b.createdAt.localeCompare(a.createdAt));
+      stats.set(face.id, {
+        total: faceActivities.length,
+        monthly,
+        lastDate: sorted[0]?.createdAt.slice(0, 10) ?? null,
+      });
+    }
+    return stats;
+  }, [faces]);
 
   return (
     <main style={{ display: "flex", flexDirection: "column", paddingBottom: 24 }}>
@@ -61,59 +80,57 @@ const FacesClient = ({ initialFaces }: Props) => {
             gap: 14,
           }}
         >
-          {faces.map((face) => (
-            <Link
-              key={face.id}
-              href={`/faces/${face.id}`}
-              style={{ textDecoration: "none" }}
-            >
-              <div
-                style={{
-                  borderRadius: 14,
-                  overflow: "hidden",
-                  background: "var(--mf-surface)",
-                  border: "0.5px solid var(--mf-line)",
-                  transition: "box-shadow 0.15s",
-                  cursor: "pointer",
-                }}
+          {faces.map((face) => {
+            const color = getFaceColor(face.id);
+            const kanji = getFaceKanji(getFaceTitle(face));
+            const stats = faceStats.get(face.id);
+            return (
+              <Link
+                key={face.id}
+                href={`/faces/${face.id}`}
+                style={{ textDecoration: "none" }}
               >
-                {/* カバー画像 or FaceBadgeフォールバック */}
-                {face.imageUrl ? (
-                  <div style={{ position: "relative", aspectRatio: "16/10" }}>
-                    <Image
-                      src={face.imageUrl}
-                      alt={face.name}
-                      fill
-                      className="object-cover"
-                      sizes="(max-width: 768px) 50vw, 200px"
-                    />
-                  </div>
-                ) : (
+                <div
+                  style={{
+                    borderRadius: 14,
+                    overflow: "hidden",
+                    background: "var(--mf-surface)",
+                    border: "0.5px solid var(--mf-line)",
+                    cursor: "pointer",
+                  }}
+                >
+                  {/* カラーバンド (56px) */}
                   <div
                     style={{
-                      aspectRatio: "16/10",
+                      height: 56,
+                      background: color,
                       display: "flex",
                       alignItems: "center",
                       justifyContent: "center",
-                      background: "var(--mf-surface-tint)",
                     }}
                   >
-                    <FaceBadge face={face} size={48} radius={13} />
+                    <div
+                      style={{
+                        width: 30,
+                        height: 30,
+                        borderRadius: 8,
+                        background: "rgba(255,255,255,0.22)",
+                        display: "flex",
+                        alignItems: "center",
+                        justifyContent: "center",
+                        fontFamily: "var(--mf-font-serif)",
+                        fontSize: 16,
+                        fontWeight: 600,
+                        color: "#fff",
+                      }}
+                    >
+                      {kanji}
+                    </div>
                   </div>
-                )}
 
-                {/* カード本文 */}
-                <div style={{ padding: "10px 12px 12px" }}>
-                  <div
-                    style={{
-                      display: "flex",
-                      alignItems: "center",
-                      gap: 6,
-                      marginBottom: 4,
-                    }}
-                  >
-                    <FaceBadge face={face} size={20} radius={5} />
-                    <span
+                  {/* カード本文 */}
+                  <div style={{ padding: "10px 12px 12px" }}>
+                    <div
                       style={{
                         fontSize: 13,
                         fontWeight: 700,
@@ -121,54 +138,83 @@ const FacesClient = ({ initialFaces }: Props) => {
                         overflow: "hidden",
                         textOverflow: "ellipsis",
                         whiteSpace: "nowrap",
+                        marginBottom: 8,
                       }}
                     >
                       {getFaceTitle(face)}
-                    </span>
+                    </div>
+
+                    {/* 統計行 */}
+                    <div
+                      style={{
+                        display: "flex",
+                        alignItems: "center",
+                        justifyContent: "space-between",
+                        marginBottom: 6,
+                      }}
+                    >
+                      <span style={{ fontSize: 11, color: "var(--mf-text-sub)" }}>
+                        <b style={{ color: "var(--mf-text)", fontWeight: 700, fontSize: 13 }}>
+                          {stats?.total ?? 0}
+                        </b>{" "}
+                        シード
+                      </span>
+                      {stats && stats.monthly > 0 && (
+                        <span
+                          style={{
+                            fontSize: 10,
+                            color: "var(--mf-accent)",
+                            fontWeight: 600,
+                            background: "rgba(212,146,42,0.1)",
+                            padding: "2px 6px",
+                            borderRadius: 999,
+                          }}
+                        >
+                          +{stats.monthly}/月
+                        </span>
+                      )}
+                    </div>
+
+                    {/* 最終投稿日 */}
+                    {stats?.lastDate && (
+                      <div
+                        style={{
+                          fontSize: 10,
+                          color: "var(--mf-text-faint)",
+                        }}
+                      >
+                        最終: {stats.lastDate.replace(/-/g, "/")}
+                      </div>
+                    )}
+
+                    {face.isPrivate && (
+                      <span
+                        style={{
+                          marginTop: 6,
+                          display: "inline-block",
+                          padding: "2px 8px",
+                          borderRadius: 999,
+                          background: "var(--mf-surface-tint)",
+                          fontSize: 10,
+                          color: "var(--mf-text-muted)",
+                          fontWeight: 600,
+                        }}
+                      >
+                        非公開
+                      </span>
+                    )}
                   </div>
-                  {face.description && (
-                    <p
-                      style={{
-                        fontSize: 11.5,
-                        lineHeight: 1.6,
-                        color: "var(--mf-text-sub)",
-                        overflow: "hidden",
-                        display: "-webkit-box",
-                        WebkitLineClamp: 2,
-                        WebkitBoxOrient: "vertical",
-                        margin: 0,
-                      }}
-                    >
-                      {face.description}
-                    </p>
-                  )}
-                  {face.isPrivate && (
-                    <span
-                      style={{
-                        marginTop: 6,
-                        display: "inline-block",
-                        padding: "2px 8px",
-                        borderRadius: 999,
-                        background: "var(--mf-surface-tint)",
-                        fontSize: 10,
-                        color: "var(--mf-text-muted)",
-                        fontWeight: 600,
-                      }}
-                    >
-                      非公開
-                    </span>
-                  )}
                 </div>
-              </div>
-            </Link>
-          ))}
+              </Link>
+            );
+          })}
 
           {/* 新規フェイス作成カード */}
           <button
             type="button"
             onClick={() => setIsModalOpen(true)}
             style={{
-              height: 156,
+              minHeight: 130,
               borderRadius: 14,
               border: "1.5px dashed var(--mf-line)",
               display: "flex",

--- a/src/components/face/FacesClient.tsx
+++ b/src/components/face/FacesClient.tsx
@@ -3,8 +3,9 @@
 import { useState } from "react";
 import Image from "next/image";
 import Link from "next/link";
-import { Plus } from "lucide-react";
 import type { Face } from "@/types/face";
+import FaceBadge from "@/components/ui/FaceBadge";
+import { getFaceTitle } from "@/lib/display";
 import CreateFaceModal from "./CreateFaceModal";
 
 type Props = {
@@ -20,38 +21,65 @@ const FacesClient = ({ initialFaces }: Props) => {
   };
 
   return (
-    <main className="flex flex-col pb-6">
-      {/* ページヘッダー */}
-      <header className="sticky top-0 z-10 border-b border-zinc-800 bg-zinc-950/80 px-4 py-3 backdrop-blur-sm">
-        <div className="flex items-center justify-between">
-          <h1 className="text-base font-bold text-zinc-100">フェイス</h1>
+    <main style={{ display: "flex", flexDirection: "column", paddingBottom: 24 }}>
+      {faces.length === 0 ? (
+        <div
+          style={{
+            display: "flex",
+            flexDirection: "column",
+            alignItems: "center",
+            gap: 16,
+            padding: "80px 0",
+          }}
+        >
+          <p style={{ fontSize: 13, color: "var(--mf-text-muted)" }}>
+            フェイスがありません
+          </p>
           <button
             type="button"
             onClick={() => setIsModalOpen(true)}
-            className="flex items-center gap-1.5 rounded-full bg-violet-600 px-4 py-1.5 text-xs font-semibold text-white shadow-md shadow-violet-900/40 transition-all hover:bg-violet-500 hover:shadow-violet-700/50 active:scale-95 active:bg-violet-700"
+            style={{
+              padding: "9px 20px",
+              borderRadius: 10,
+              background: "var(--mf-brand)",
+              color: "#fff",
+              fontSize: 13,
+              fontWeight: 700,
+              border: "none",
+              cursor: "pointer",
+            }}
           >
-            <Plus size={14} aria-hidden="true" strokeWidth={2.5} />
-            新規作成
+            最初のフェイスを作る
           </button>
         </div>
-      </header>
-
-      <div className="px-4 pt-4">
-        {faces.length === 0 ? (
-          <p className="py-12 text-center text-sm text-zinc-500">
-            フェイスがありません
-          </p>
-        ) : (
-          <div className="grid grid-cols-2 gap-3">
-            {faces.map((face) => (
-              <Link
-                key={face.id}
-                href={`/faces/${face.id}`}
-                className="flex flex-col overflow-hidden rounded-xl bg-zinc-800/60 transition-colors hover:bg-zinc-700/80 active:bg-zinc-700"
+      ) : (
+        <div
+          style={{
+            padding: "20px 28px 32px",
+            display: "grid",
+            gridTemplateColumns: "repeat(auto-fill, minmax(160px, 1fr))",
+            gap: 14,
+          }}
+        >
+          {faces.map((face) => (
+            <Link
+              key={face.id}
+              href={`/faces/${face.id}`}
+              style={{ textDecoration: "none" }}
+            >
+              <div
+                style={{
+                  borderRadius: 14,
+                  overflow: "hidden",
+                  background: "var(--mf-surface)",
+                  border: "0.5px solid var(--mf-line)",
+                  transition: "box-shadow 0.15s",
+                  cursor: "pointer",
+                }}
               >
-                {/* テーマ画像 or 絵文字フォールバック */}
+                {/* カバー画像 or FaceBadgeフォールバック */}
                 {face.imageUrl ? (
-                  <div className="relative aspect-video w-full">
+                  <div style={{ position: "relative", aspectRatio: "16/10" }}>
                     <Image
                       src={face.imageUrl}
                       alt={face.name}
@@ -61,42 +89,106 @@ const FacesClient = ({ initialFaces }: Props) => {
                     />
                   </div>
                 ) : (
-                  <div className="flex aspect-video w-full items-center justify-center bg-zinc-700/60">
-                    {face.emoji && (
-                      <span className="text-4xl leading-none" aria-hidden="true">
-                        {face.emoji}
-                      </span>
-                    )}
+                  <div
+                    style={{
+                      aspectRatio: "16/10",
+                      display: "flex",
+                      alignItems: "center",
+                      justifyContent: "center",
+                      background: "var(--mf-surface-tint)",
+                    }}
+                  >
+                    <FaceBadge face={face} size={48} radius={13} />
                   </div>
                 )}
+
                 {/* カード本文 */}
-                <div className="flex flex-col gap-1 p-3">
-                  <div className="flex items-center gap-1.5">
-                    {face.emoji && (
-                      <span className="text-base leading-none" aria-hidden="true">
-                        {face.emoji}
-                      </span>
-                    )}
-                    <span className="truncate text-sm font-semibold text-zinc-100">
-                      {face.name}
+                <div style={{ padding: "10px 12px 12px" }}>
+                  <div
+                    style={{
+                      display: "flex",
+                      alignItems: "center",
+                      gap: 6,
+                      marginBottom: 4,
+                    }}
+                  >
+                    <FaceBadge face={face} size={20} radius={5} />
+                    <span
+                      style={{
+                        fontSize: 13,
+                        fontWeight: 700,
+                        color: "var(--mf-brand)",
+                        overflow: "hidden",
+                        textOverflow: "ellipsis",
+                        whiteSpace: "nowrap",
+                      }}
+                    >
+                      {getFaceTitle(face)}
                     </span>
                   </div>
                   {face.description && (
-                    <span className="line-clamp-2 text-xs text-zinc-400">
+                    <p
+                      style={{
+                        fontSize: 11.5,
+                        lineHeight: 1.6,
+                        color: "var(--mf-text-sub)",
+                        overflow: "hidden",
+                        display: "-webkit-box",
+                        WebkitLineClamp: 2,
+                        WebkitBoxOrient: "vertical",
+                        margin: 0,
+                      }}
+                    >
                       {face.description}
-                    </span>
+                    </p>
                   )}
                   {face.isPrivate && (
-                    <span className="mt-0.5 self-start rounded-full bg-zinc-700 px-2 py-0.5 text-[10px] text-zinc-400">
+                    <span
+                      style={{
+                        marginTop: 6,
+                        display: "inline-block",
+                        padding: "2px 8px",
+                        borderRadius: 999,
+                        background: "var(--mf-surface-tint)",
+                        fontSize: 10,
+                        color: "var(--mf-text-muted)",
+                        fontWeight: 600,
+                      }}
+                    >
                       非公開
                     </span>
                   )}
                 </div>
-              </Link>
-            ))}
-          </div>
-        )}
-      </div>
+              </div>
+            </Link>
+          ))}
+
+          {/* 新規フェイス作成カード */}
+          <button
+            type="button"
+            onClick={() => setIsModalOpen(true)}
+            style={{
+              height: 156,
+              borderRadius: 14,
+              border: "1.5px dashed var(--mf-line)",
+              display: "flex",
+              flexDirection: "column",
+              alignItems: "center",
+              justifyContent: "center",
+              gap: 6,
+              color: "var(--mf-text-muted)",
+              background: "transparent",
+              cursor: "pointer",
+            }}
+          >
+            <svg width={24} height={24} viewBox="0 0 20 20" fill="none" stroke="currentColor" strokeWidth={2} strokeLinecap="round">
+              <path d="M10 4v12M4 10h12" />
+            </svg>
+            <div style={{ fontSize: 12.5, fontWeight: 600 }}>新しいフェイスを作る</div>
+            <div style={{ fontSize: 10.5 }}>多面性を、もう一つ</div>
+          </button>
+        </div>
+      )}
 
       <CreateFaceModal
         isOpen={isModalOpen}

--- a/src/components/home/ActivityFeed.tsx
+++ b/src/components/home/ActivityFeed.tsx
@@ -4,19 +4,13 @@ import { activityRepository } from "@/repositories/activity-repository";
 import { faceRepository } from "@/repositories/face-repository";
 import { userRepository } from "@/repositories/user-repository";
 import { useDetailPanel } from "@/lib/detail-panel-context";
-import { createLookupMap, getFaceTitle } from "@/lib/display";
-import ActivityCard from "@/components/ui/ActivityCard";
+import { createLookupMap } from "@/lib/display";
+import SeedRow from "@/components/ui/SeedRow";
 
 type ActivityFeedProps = {
-  /** フィルタするフェイス ID。null のときは全フェイスを表示 */
   selectedFaceId?: string | null;
 };
 
-/**
- * ホームフィード。
- * currentUser のアクティビティを時系列降順（最新が先頭）で表示する。
- * selectedFaceId が指定されている場合は該当フェイスのみに絞り込む。
- */
 const ActivityFeed = ({ selectedFaceId }: ActivityFeedProps) => {
   const { openActivity } = useDetailPanel();
   const user = userRepository.getCurrentUser();
@@ -26,7 +20,6 @@ const ActivityFeed = ({ selectedFaceId }: ActivityFeedProps) => {
     ? allActivities.filter((a) => a.faceId === selectedFaceId)
     : allActivities;
 
-  // フェイスを O(1) で引けるようにマップ化
   const faceCache = createLookupMap(
     displayActivities.flatMap((activity) => {
       const face = faceRepository.findById(activity.faceId);
@@ -37,31 +30,35 @@ const ActivityFeed = ({ selectedFaceId }: ActivityFeedProps) => {
 
   if (displayActivities.length === 0) {
     return (
-      <p className="text-center text-sm text-zinc-500 py-16">
+      <p
+        style={{
+          textAlign: "center",
+          fontSize: 13,
+          color: "var(--mf-text-muted)",
+          padding: "64px 0",
+        }}
+      >
         アクティビティがありません
       </p>
     );
   }
 
   return (
-    <ul className="flex flex-col gap-3">
+    <div>
       {displayActivities.map((activity, index) => {
         const face = faceCache.get(activity.faceId);
         if (!face) return null;
         return (
-          <li key={activity.id}>
-            <ActivityCard
-              activity={activity}
-              user={user}
-              faceTitle={getFaceTitle(face)}
-              faceId={face.id}
-              priority={index === 0}
-              onClick={() => openActivity(activity.id)}
-            />
-          </li>
+          <SeedRow
+            key={activity.id}
+            activity={activity}
+            face={face}
+            onClick={() => openActivity(activity.id)}
+            noBorder={index === displayActivities.length - 1}
+          />
         );
       })}
-    </ul>
+    </div>
   );
 };
 

--- a/src/components/home/ActivityTileCalendar.tsx
+++ b/src/components/home/ActivityTileCalendar.tsx
@@ -2,7 +2,6 @@
 
 import { useState, useMemo } from "react";
 import { type Activity } from "@/types/activity";
-import { cn } from "@/lib/utils";
 
 type ActivityTileCalendarProps = {
   activities: Activity[];
@@ -13,13 +12,13 @@ const REFERENCE_DATE = new Date("2026-04-01");
 
 const DAY_LABELS = ["日", "月", "火", "水", "木", "金", "土"] as const;
 
-/** 1日の投稿数に応じた 5 段階カラークラスを返す */
-const getColorClass = (count: number): string => {
-  if (count === 0) return "bg-zinc-800";
-  if (count === 1) return "bg-green-200";
-  if (count <= 3) return "bg-green-400";
-  if (count <= 5) return "bg-green-500";
-  return "bg-green-700";
+/** 1日の投稿数に応じた 5 段階カラーを返す（MF amber scale） */
+const getColorStyle = (count: number): string => {
+  if (count === 0) return "var(--mf-surface-tint)";
+  if (count === 1) return "rgba(212,146,42,0.25)";
+  if (count <= 3) return "rgba(212,146,42,0.50)";
+  if (count <= 5) return "rgba(212,146,42,0.75)";
+  return "var(--mf-accent)";
 };
 
 /** Date を "yyyy-MM-dd" キーへ変換 */
@@ -110,23 +109,39 @@ const ActivityTileCalendar = ({ activities }: ActivityTileCalendarProps) => {
     setSelectedWeekIdx((prev) => (prev === wIdx ? null : wIdx));
   };
 
+  const LEGEND_COUNTS = [0, 1, 2, 4, 6];
+
   return (
-    <section className="px-4">
-      <h2 className="mb-3 text-sm font-semibold uppercase tracking-wider text-zinc-500">
+    <section>
+      <h2
+        style={{
+          fontSize: 10.5,
+          fontWeight: 700,
+          letterSpacing: 0.6,
+          textTransform: "uppercase",
+          color: "var(--mf-text-muted)",
+          marginBottom: 10,
+        }}
+      >
         振り返り
       </h2>
 
       {/* カレンダー本体（横スクロール） */}
-      <div className="overflow-x-auto rounded-xl bg-zinc-800/40 p-3 pb-4">
+      <div
+        className="overflow-x-auto mf-scroll"
+        style={{
+          borderRadius: 12,
+          background: "var(--mf-bg-paper)",
+          border: "0.5px solid var(--mf-line)",
+          padding: "10px 12px 12px",
+        }}
+      >
         {/* 月ラベル行 */}
         <div className="flex gap-[2px] mb-1 pl-[26px]">
           {weeks.map((_, wIdx) => (
-            <div
-              key={wIdx}
-              className="flex-shrink-0 w-[13px]"
-            >
+            <div key={wIdx} style={{ flexShrink: 0, width: 13 }}>
               {monthLabels[wIdx] && (
-                <span className="text-[9px] leading-none text-zinc-500">
+                <span style={{ fontSize: 9, lineHeight: 1, color: "var(--mf-text-muted)" }}>
                   {monthLabels[wIdx]}
                 </span>
               )}
@@ -135,16 +150,16 @@ const ActivityTileCalendar = ({ activities }: ActivityTileCalendarProps) => {
         </div>
 
         {/* 曜日ラベル + セルグリッド */}
-        <div className="flex items-start gap-[6px]">
-          {/* 曜日ラベル（月・水・金 のみ表示） */}
-          <div className="flex flex-col flex-shrink-0 gap-[2px]">
+        <div style={{ display: "flex", alignItems: "flex-start", gap: 6 }}>
+          {/* 曜日ラベル */}
+          <div style={{ display: "flex", flexDirection: "column", flexShrink: 0, gap: 2 }}>
             {DAY_LABELS.map((label, i) => (
               <div
                 key={i}
-                className="w-[18px] h-[11px] flex items-center justify-end"
+                style={{ width: 18, height: 11, display: "flex", alignItems: "center", justifyContent: "flex-end" }}
               >
                 {(i === 1 || i === 3 || i === 5) && (
-                  <span className="text-[9px] leading-none text-zinc-500">
+                  <span style={{ fontSize: 9, lineHeight: 1, color: "var(--mf-text-muted)" }}>
                     {label}
                   </span>
                 )}
@@ -153,7 +168,7 @@ const ActivityTileCalendar = ({ activities }: ActivityTileCalendarProps) => {
           </div>
 
           {/* 週 × 日 のセル群 */}
-          <div className="flex gap-[2px]">
+          <div style={{ display: "flex", gap: 2 }}>
             {weeks.map((week, wIdx) => {
               const isSelected = selectedWeekIdx === wIdx;
               return (
@@ -162,19 +177,29 @@ const ActivityTileCalendar = ({ activities }: ActivityTileCalendarProps) => {
                   type="button"
                   aria-label={`${toDateKey(week.startDate)} の週`}
                   onClick={() => handleWeekClick(wIdx)}
-                  className="flex flex-col flex-shrink-0 gap-[2px] w-[11px] focus:outline-none"
+                  style={{
+                    display: "flex",
+                    flexDirection: "column",
+                    flexShrink: 0,
+                    gap: 2,
+                    width: 11,
+                    background: "none",
+                    border: "none",
+                    padding: 0,
+                    cursor: "pointer",
+                  }}
                 >
                   {week.days.map((day) => (
                     <div
                       key={day.key}
                       title={`${day.key}: ${day.count}件`}
-                      className={cn(
-                        "w-[11px] h-[11px] rounded-sm transition-all",
-                        getColorClass(day.count),
-                        isSelected
-                          ? "ring-1 ring-violet-400 ring-offset-1 ring-offset-zinc-900"
-                          : "hover:brightness-110",
-                      )}
+                      style={{
+                        width: 11,
+                        height: 11,
+                        borderRadius: 2,
+                        background: getColorStyle(day.count),
+                        boxShadow: isSelected ? `0 0 0 1px var(--mf-accent), 0 0 0 2px var(--mf-bg-paper)` : "none",
+                      }}
                     />
                   ))}
                 </button>
@@ -184,44 +209,68 @@ const ActivityTileCalendar = ({ activities }: ActivityTileCalendarProps) => {
         </div>
 
         {/* 凡例 */}
-        <div className="flex items-center justify-end gap-[3px] mt-2.5">
-          <span className="text-[9px] text-zinc-500 mr-1">少</span>
-          {(["bg-zinc-800", "bg-green-200", "bg-green-400", "bg-green-500", "bg-green-700"] as const).map(
-            (cls, i) => (
-              <div
-                key={i}
-                className={cn("w-[11px] h-[11px] rounded-sm", cls)}
-              />
-            ),
-          )}
-          <span className="text-[9px] text-zinc-500 ml-1">多</span>
+        <div style={{ display: "flex", alignItems: "center", justifyContent: "flex-end", gap: 3, marginTop: 8 }}>
+          <span style={{ fontSize: 9, color: "var(--mf-text-muted)", marginRight: 2 }}>少</span>
+          {LEGEND_COUNTS.map((count, i) => (
+            <div
+              key={i}
+              style={{ width: 11, height: 11, borderRadius: 2, background: getColorStyle(count) }}
+            />
+          ))}
+          <span style={{ fontSize: 9, color: "var(--mf-text-muted)", marginLeft: 2 }}>多</span>
         </div>
       </div>
 
       {/* 選択週のアクティビティ一覧 */}
       {selectedWeekIdx !== null && (
-        <div className="mt-4">
-          <p className="mb-2 text-xs text-zinc-500">
-            {toDateKey(weeks[selectedWeekIdx].startDate).replace(/-/g, "/")}{" "}
-            〜{" "}
+        <div style={{ marginTop: 14 }}>
+          <p style={{ fontSize: 11.5, color: "var(--mf-text-muted)", marginBottom: 8 }}>
+            {toDateKey(weeks[selectedWeekIdx].startDate).replace(/-/g, "/")}
+            {" 〜 "}
             {toDateKey(weeks[selectedWeekIdx].endDate).replace(/-/g, "/")}
             の記録
           </p>
           {selectedWeekActivities.length === 0 ? (
-            <p className="rounded-xl bg-zinc-800/40 p-4 text-center text-sm text-zinc-500">
+            <p
+              style={{
+                borderRadius: 12,
+                padding: "14px",
+                textAlign: "center",
+                fontSize: 13,
+                color: "var(--mf-text-muted)",
+                background: "var(--mf-bg-paper)",
+                border: "0.5px solid var(--mf-line)",
+              }}
+            >
               この週には記録がありません
             </p>
           ) : (
-            <ul className="flex flex-col gap-2">
+            <ul style={{ display: "flex", flexDirection: "column", gap: 6, listStyle: "none", padding: 0, margin: 0 }}>
               {selectedWeekActivities.map((act) => (
                 <li
                   key={act.id}
-                  className="rounded-xl bg-zinc-800/60 p-3 text-sm"
+                  style={{
+                    borderRadius: 10,
+                    background: "var(--mf-surface-card)",
+                    border: "0.5px solid var(--mf-line)",
+                    padding: "10px 12px",
+                    fontSize: 13,
+                  }}
                 >
-                  <p className="mb-1 text-xs text-zinc-500">
+                  <p style={{ fontSize: 11, color: "var(--mf-text-muted)", marginBottom: 4 }}>
                     {isoToDateKey(act.createdAt).replace(/-/g, "/")}
                   </p>
-                  <p className="line-clamp-3 leading-relaxed text-zinc-200">
+                  <p
+                    style={{
+                      lineHeight: 1.6,
+                      color: "var(--mf-ink)",
+                      overflow: "hidden",
+                      display: "-webkit-box",
+                      WebkitLineClamp: 3,
+                      WebkitBoxOrient: "vertical",
+                      margin: 0,
+                    }}
+                  >
                     {act.body}
                   </p>
                 </li>

--- a/src/components/home/FaceFilterBar.tsx
+++ b/src/components/home/FaceFilterBar.tsx
@@ -1,7 +1,7 @@
 "use client";
 
 import { type Face } from "@/types/face";
-import { cn } from "@/lib/utils";
+import FaceBadge from "@/components/ui/FaceBadge";
 
 type FaceFilterBarProps = {
   faces: Face[];
@@ -9,48 +9,64 @@ type FaceFilterBarProps = {
   onSelect: (faceId: string | null) => void;
 };
 
-/**
- * フェイスアイコン一覧（横スクロール）。
- * タップで該当フェイスのアクティビティに絞り込む Client Component。
- * 「すべて」ボタンでフィルタを解除できる。
- */
 const FaceFilterBar = ({ faces, selectedFaceId, onSelect }: FaceFilterBarProps) => {
-  const handleSelectAll = () => {
-    onSelect(null);
-  };
-
   const handleSelectFace = (faceId: string) => {
-    // 同じフェイスを再タップしたらフィルタ解除
     onSelect(selectedFaceId === faceId ? null : faceId);
   };
 
   return (
-    <div className="overflow-x-auto border-b border-zinc-800 px-4 py-3">
-      <div className="flex items-center gap-2 w-max">
+    <div
+      className="overflow-x-auto mf-scroll"
+      style={{ borderBottom: "0.5px solid var(--mf-line)", padding: "12px 16px" }}
+    >
+      <div style={{ display: "flex", alignItems: "center", gap: 10, width: "max-content" }}>
         {/* すべてボタン */}
         <button
           type="button"
-          onClick={handleSelectAll}
-          className={cn(
-            "flex flex-col items-center gap-1 flex-shrink-0",
-            "focus:outline-none",
-          )}
+          onClick={() => onSelect(null)}
+          style={{
+            display: "flex",
+            flexDirection: "column",
+            alignItems: "center",
+            gap: 4,
+            background: "none",
+            border: "none",
+            cursor: "pointer",
+            padding: 0,
+          }}
         >
           <span
-            className={cn(
-              "flex h-10 w-10 items-center justify-center rounded-full text-lg transition-all",
-              selectedFaceId === null
-                ? "bg-violet-600 ring-2 ring-violet-400 ring-offset-2 ring-offset-zinc-950"
-                : "bg-zinc-800 hover:bg-zinc-700",
-            )}
+            style={{
+              width: 40,
+              height: 40,
+              borderRadius: "50%",
+              background:
+                selectedFaceId === null
+                  ? "var(--mf-brand)"
+                  : "var(--mf-surface-tint)",
+              display: "flex",
+              alignItems: "center",
+              justifyContent: "center",
+              fontSize: 18,
+              transition: "background 0.15s",
+            }}
           >
             🌐
           </span>
           <span
-            className={cn(
-              "text-[10px] leading-none max-w-[44px] truncate",
-              selectedFaceId === null ? "text-violet-400" : "text-zinc-500",
-            )}
+            style={{
+              fontSize: 10,
+              lineHeight: 1,
+              maxWidth: 44,
+              overflow: "hidden",
+              textOverflow: "ellipsis",
+              whiteSpace: "nowrap",
+              color:
+                selectedFaceId === null
+                  ? "var(--mf-brand)"
+                  : "var(--mf-text-muted)",
+              fontWeight: selectedFaceId === null ? 700 : 500,
+            }}
           >
             すべて
           </span>
@@ -59,33 +75,42 @@ const FaceFilterBar = ({ faces, selectedFaceId, onSelect }: FaceFilterBarProps) 
         {/* 各フェイスボタン */}
         {faces.map((face) => {
           const isActive = selectedFaceId === face.id;
-          const icon = face.emoji ?? face.name.slice(0, 1);
-
           return (
             <button
               key={face.id}
               type="button"
               onClick={() => handleSelectFace(face.id)}
-              className={cn(
-                "flex flex-col items-center gap-1 flex-shrink-0",
-                "focus:outline-none",
-              )}
+              style={{
+                display: "flex",
+                flexDirection: "column",
+                alignItems: "center",
+                gap: 4,
+                background: "none",
+                border: "none",
+                cursor: "pointer",
+                padding: 0,
+              }}
             >
-              <span
-                className={cn(
-                  "flex h-10 w-10 items-center justify-center rounded-full text-lg transition-all",
-                  isActive
-                    ? "bg-violet-600 ring-2 ring-violet-400 ring-offset-2 ring-offset-zinc-950"
-                    : "bg-zinc-800 hover:bg-zinc-700",
-                )}
+              <div
+                style={{
+                  borderRadius: 11,
+                  boxShadow: isActive ? "0 0 0 2.5px var(--mf-accent)" : "none",
+                  transition: "box-shadow 0.15s",
+                }}
               >
-                {icon}
-              </span>
+                <FaceBadge face={face} size={40} radius={11} />
+              </div>
               <span
-                className={cn(
-                  "text-[10px] leading-none max-w-[44px] truncate",
-                  isActive ? "text-violet-400" : "text-zinc-500",
-                )}
+                style={{
+                  fontSize: 10,
+                  lineHeight: 1,
+                  maxWidth: 44,
+                  overflow: "hidden",
+                  textOverflow: "ellipsis",
+                  whiteSpace: "nowrap",
+                  color: isActive ? "var(--mf-brand)" : "var(--mf-text-muted)",
+                  fontWeight: isActive ? 700 : 500,
+                }}
               >
                 {face.name}
               </span>

--- a/src/components/home/HomeClient.tsx
+++ b/src/components/home/HomeClient.tsx
@@ -1,19 +1,189 @@
 "use client";
 
-import { useState } from "react";
+import { useState, useMemo } from "react";
 import { faceRepository } from "@/repositories/face-repository";
+import { activityRepository } from "@/repositories/activity-repository";
 import { userRepository } from "@/repositories/user-repository";
 import FaceFilterBar from "./FaceFilterBar";
 import ActivityFeed from "./ActivityFeed";
+import PostModal from "@/components/ui/PostModal";
+import FaceBadge from "@/components/ui/FaceBadge";
+import FaceChip from "@/components/ui/FaceChip";
+import { getFaceTitle } from "@/lib/display";
+
+const REFERENCE_DATE = new Date("2026-04-01");
 
 const HomeClient = () => {
   const [selectedFaceId, setSelectedFaceId] = useState<string | null>(null);
+  const [isModalOpen, setIsModalOpen] = useState(false);
 
   const user = userRepository.getCurrentUser();
   const faces = faceRepository.listByUserId(user.id);
 
+  // On This Day: 同じ月日の過去のアクティビティを取得
+  const onThisDayActivities = useMemo(() => {
+    const mmdd = REFERENCE_DATE.toISOString().slice(5, 10); // "04-01"
+    const allUserActivities = activityRepository.listByUserId(user.id);
+    return allUserActivities
+      .filter((a) => {
+        const actDate = a.createdAt.slice(0, 10);
+        return actDate.slice(5) === mmdd && !actDate.startsWith("2026");
+      })
+      .slice(0, 1);
+  }, [user.id]);
+
+  const defaultFace = faces[0] ?? null;
+
   return (
     <div style={{ display: "flex", flexDirection: "column" }}>
+      {/* インラインコンポーズ */}
+      <div
+        style={{
+          padding: "12px 28px",
+          borderBottom: "0.5px solid var(--mf-line)",
+        }}
+      >
+        <button
+          type="button"
+          onClick={() => setIsModalOpen(true)}
+          style={{
+            width: "100%",
+            display: "flex",
+            alignItems: "center",
+            gap: 10,
+            padding: "10px 14px",
+            borderRadius: 14,
+            background: "var(--mf-surface)",
+            border: "0.5px solid var(--mf-line)",
+            cursor: "pointer",
+            textAlign: "left",
+          }}
+        >
+          {defaultFace && (
+            <FaceBadge face={defaultFace} size={32} radius={9} />
+          )}
+          <span
+            style={{
+              flex: 1,
+              fontSize: 14,
+              color: "var(--mf-text-faint)",
+              fontFamily: "var(--mf-font-sans)",
+            }}
+          >
+            今、何を書く？
+          </span>
+          <span
+            style={{
+              padding: "5px 14px",
+              borderRadius: 999,
+              background: "var(--mf-accent)",
+              color: "#fff",
+              fontSize: 12,
+              fontWeight: 700,
+              flexShrink: 0,
+            }}
+          >
+            投稿
+          </span>
+        </button>
+      </div>
+
+      {/* On This Day */}
+      {onThisDayActivities.length > 0 && (() => {
+        const act = onThisDayActivities[0];
+        const face = faceRepository.findById(act.faceId);
+        const year = parseInt(act.createdAt.slice(0, 4), 10);
+        const yearsAgo = REFERENCE_DATE.getFullYear() - year;
+        return (
+          <div
+            style={{
+              margin: "12px 28px",
+              borderRadius: 14,
+              border: "0.5px solid var(--mf-line)",
+              overflow: "hidden",
+              background: "var(--mf-surface-card)",
+            }}
+          >
+            {/* アンバーライン */}
+            <div style={{ height: 3, background: "var(--mf-accent)" }} />
+            <div style={{ padding: "12px 14px" }}>
+              <div
+                style={{
+                  display: "flex",
+                  alignItems: "center",
+                  gap: 8,
+                  marginBottom: 8,
+                }}
+              >
+                <svg width={12} height={12} viewBox="0 0 16 16" fill="none" stroke="var(--mf-accent)" strokeWidth={1.8} strokeLinecap="round" strokeLinejoin="round">
+                  <circle cx={8} cy={8} r={6} />
+                  <path d="M8 5v3l2 2" />
+                </svg>
+                <span
+                  style={{
+                    fontSize: 11,
+                    fontWeight: 700,
+                    color: "var(--mf-accent)",
+                    letterSpacing: 0.3,
+                  }}
+                >
+                  {yearsAgo}年前の今日
+                </span>
+                {face && <FaceChip faceId={face.id} title={getFaceTitle(face)} />}
+              </div>
+              <p
+                style={{
+                  fontSize: 13.5,
+                  lineHeight: 1.7,
+                  color: "var(--mf-ink)",
+                  margin: 0,
+                  overflow: "hidden",
+                  display: "-webkit-box",
+                  WebkitLineClamp: 3,
+                  WebkitBoxOrient: "vertical",
+                }}
+              >
+                {act.body}
+              </p>
+              <p
+                style={{
+                  marginTop: 8,
+                  fontSize: 11,
+                  color: "var(--mf-text-faint)",
+                  fontStyle: "italic",
+                  fontFamily: "var(--mf-font-serif-en)",
+                  margin: "8px 0 0",
+                }}
+              >
+                {act.createdAt.slice(0, 10).replace(/-/g, "/")} の記録
+              </p>
+            </div>
+          </div>
+        );
+      })()}
+
+      {/* 最近のシード セクションヘッダー */}
+      <div
+        style={{
+          display: "flex",
+          alignItems: "center",
+          justifyContent: "space-between",
+          padding: "14px 28px 6px",
+        }}
+      >
+        <span
+          style={{
+            fontSize: 11,
+            fontWeight: 700,
+            letterSpacing: 0.6,
+            textTransform: "uppercase",
+            color: "var(--mf-text-muted)",
+          }}
+        >
+          最近のシード
+        </span>
+      </div>
+
       <FaceFilterBar
         faces={faces}
         selectedFaceId={selectedFaceId}
@@ -22,6 +192,11 @@ const HomeClient = () => {
       <div style={{ padding: "0 28px" }}>
         <ActivityFeed selectedFaceId={selectedFaceId} />
       </div>
+
+      <PostModal
+        isOpen={isModalOpen}
+        onClose={() => setIsModalOpen(false)}
+      />
     </div>
   );
 };

--- a/src/components/home/HomeClient.tsx
+++ b/src/components/home/HomeClient.tsx
@@ -6,31 +6,20 @@ import { userRepository } from "@/repositories/user-repository";
 import FaceFilterBar from "./FaceFilterBar";
 import ActivityFeed from "./ActivityFeed";
 
-/**
- * フェイスフィルタ状態を管理する Client Component。
- * FaceFilterBar と ActivityFeed を束ね、フィルタ連携を担う。
- */
 const HomeClient = () => {
   const [selectedFaceId, setSelectedFaceId] = useState<string | null>(null);
 
   const user = userRepository.getCurrentUser();
   const faces = faceRepository.listByUserId(user.id);
 
-  const handleSelectFace = (faceId: string | null) => {
-    setSelectedFaceId(faceId);
-  };
-
   return (
-    <div className="flex flex-col">
-      {/* フェイスフィルタバー */}
+    <div style={{ display: "flex", flexDirection: "column" }}>
       <FaceFilterBar
         faces={faces}
         selectedFaceId={selectedFaceId}
-        onSelect={handleSelectFace}
+        onSelect={setSelectedFaceId}
       />
-
-      {/* アクティビティフィード */}
-      <div className="px-4 py-4">
+      <div style={{ padding: "0 28px" }}>
         <ActivityFeed selectedFaceId={selectedFaceId} />
       </div>
     </div>

--- a/src/components/home/HomeProfile.tsx
+++ b/src/components/home/HomeProfile.tsx
@@ -1,46 +1,56 @@
 import { userRepository } from "@/repositories/user-repository";
 import { faceRepository } from "@/repositories/face-repository";
 import { activityRepository } from "@/repositories/activity-repository";
-import Avatar from "@/components/ui/Avatar";
-import Badge from "@/components/ui/Badge";
 import ActivityTileCalendar from "./ActivityTileCalendar";
 
-/**
- * ホーム上部のプロフィールエリア（Server Component）。
- * ユーザーアイコン・名前・バッジ・フェイス数・アクティビティ数・タイルカレンダーを表示する。
- */
 const HomeProfile = () => {
   const user = userRepository.getCurrentUser();
   const faces = faceRepository.listByUserId(user.id);
   const activities = activityRepository.listByUserId(user.id);
 
   return (
-    <div className="flex flex-col gap-4 px-4 pt-6 pb-4">
-      {/* アバター・名前・バッジ */}
-      <div className="flex items-center gap-3">
-        <Avatar
-          src={user.avatarUrl}
-          alt={user.name}
-          size="lg"
-          className="ring-2 ring-violet-500/60"
-        />
-        <div className="flex flex-col gap-0.5">
-          <div className="flex items-center gap-2">
-            <span className="text-lg font-bold text-zinc-100">{user.name}</span>
-            {user.badge && <Badge emoji={user.badge} />}
+    <div style={{ display: "flex", flexDirection: "column", gap: 16, padding: "20px 28px 12px" }}>
+      {/* アバター・名前 */}
+      <div style={{ display: "flex", alignItems: "center", gap: 12 }}>
+        <div
+          style={{
+            width: 44,
+            height: 44,
+            borderRadius: "50%",
+            background: "var(--mf-brand)",
+            color: "#fff",
+            display: "flex",
+            alignItems: "center",
+            justifyContent: "center",
+            fontSize: 18,
+            fontWeight: 700,
+            flexShrink: 0,
+          }}
+        >
+          {user.name.slice(0, 1)}
+        </div>
+        <div>
+          <div style={{ fontSize: 16, fontWeight: 700, color: "var(--mf-brand)" }}>
+            {user.name}
           </div>
-          {/* フェイス数・アクティビティ数 */}
-          <div className="flex items-center gap-4 text-sm text-zinc-400">
+          <div
+            style={{
+              display: "flex",
+              alignItems: "center",
+              gap: 12,
+              fontSize: 12.5,
+              color: "var(--mf-text-muted)",
+              marginTop: 2,
+            }}
+          >
             <span>
-              <span className="font-semibold text-zinc-200">{faces.length}</span>{" "}
+              <b style={{ color: "var(--mf-text)", fontWeight: 700 }}>{faces.length}</b>{" "}
               フェイス
             </span>
-            <span className="w-px h-3.5 bg-zinc-700 inline-block" />
+            <span style={{ width: 1, height: 12, background: "var(--mf-line)", display: "inline-block" }} />
             <span>
-              <span className="font-semibold text-zinc-200">
-                {activities.length}
-              </span>{" "}
-              アクティビティ
+              <b style={{ color: "var(--mf-text)", fontWeight: 700 }}>{activities.length}</b>{" "}
+              シード
             </span>
           </div>
         </div>

--- a/src/components/notifications/NotificationList.tsx
+++ b/src/components/notifications/NotificationList.tsx
@@ -1,6 +1,5 @@
 "use client";
 
-import Avatar from "@/components/ui/Avatar";
 import { notificationRepository } from "@/repositories/notification-repository";
 import { userRepository } from "@/repositories/user-repository";
 import { faceRepository } from "@/repositories/face-repository";
@@ -9,18 +8,13 @@ import { type Notification } from "@/types/notification";
 import { type User } from "@/types/user";
 import { formatRelativeTime } from "@/lib/format-relative-time";
 import { createLookupMap, getFaceTitle } from "@/lib/display";
-import { cn } from "@/lib/utils";
 import { useDetailPanel } from "@/lib/detail-panel-context";
-
-// ─── 通知アイテム ──────────────────────────────────────────────
 
 type NotificationItemProps = {
   notification: Notification;
   fromUser: User;
   detail: string;
-  /** リンク通知の場合のアクティビティ本文スニペット（任意） */
   activitySnippet?: string;
-  /** リンク通知の場合の紐づくアクティビティID */
   activityId?: string;
 };
 
@@ -35,49 +29,90 @@ const NotificationItem = ({
   const isLink = notification.type === "link";
 
   const isSelected =
-    state.type === "activity" && activityId !== undefined && state.activityId === activityId;
-
-  const handleClick = () => {
-    if (activityId) openActivity(activityId);
-  };
+    state.type === "activity" &&
+    activityId !== undefined &&
+    state.activityId === activityId;
 
   return (
     <li
-      onClick={handleClick}
-      className={cn(
-        "flex gap-3 rounded-2xl bg-zinc-800/60 p-4 transition",
-        activityId && "md:cursor-pointer hover:bg-zinc-800",
-        isSelected && "ring-1 ring-violet-500/40 bg-zinc-800",
-      )}
+      onClick={() => {
+        if (activityId) openActivity(activityId);
+      }}
+      style={{
+        display: "flex",
+        gap: 12,
+        padding: "14px 16px",
+        borderRadius: 14,
+        background: isSelected
+          ? "rgba(30,42,74,0.06)"
+          : "var(--mf-surface-card)",
+        border: `0.5px solid ${isSelected ? "var(--mf-brand)" : "var(--mf-line)"}`,
+        cursor: activityId ? "pointer" : "default",
+        transition: "background 0.15s, border 0.15s",
+      }}
     >
-      {/* アバター */}
-      <div className="shrink-0">
-        <Avatar src={fromUser.avatarUrl} alt={fromUser.name} size="md" />
+      {/* ユーザー頭文字アバター */}
+      <div
+        style={{
+          width: 36,
+          height: 36,
+          borderRadius: "50%",
+          background: "var(--mf-brand)",
+          color: "#fff",
+          display: "flex",
+          alignItems: "center",
+          justifyContent: "center",
+          fontSize: 14,
+          fontWeight: 700,
+          flexShrink: 0,
+        }}
+      >
+        {fromUser.name.slice(0, 1)}
       </div>
 
       {/* 本文 */}
-      <div className="flex flex-1 flex-col gap-1.5 overflow-hidden">
-        {/* アクション行 */}
-        <div className="flex items-start justify-between gap-2">
-          <p className="text-sm text-zinc-200 leading-snug">
-            <span className="font-semibold text-zinc-100">{fromUser.name}</span>
+      <div style={{ flex: 1, minWidth: 0, display: "flex", flexDirection: "column", gap: 6 }}>
+        <div style={{ display: "flex", alignItems: "flex-start", justifyContent: "space-between", gap: 8 }}>
+          <p style={{ fontSize: 13, color: "var(--mf-text)", lineHeight: 1.5, margin: 0 }}>
+            <span style={{ fontWeight: 700 }}>{fromUser.name}</span>
             {" さんが "}
-            <span className="text-violet-400">{detail}</span>
+            <span style={{ color: "var(--mf-accent)", fontWeight: 600 }}>{detail}</span>
           </p>
-          <span className="shrink-0 text-xs text-zinc-500">
+          <span style={{ flexShrink: 0, fontSize: 11.5, color: "var(--mf-text-muted)" }}>
             {formatRelativeTime(notification.createdAt)}
           </span>
         </div>
 
-        {/* リンク通知: アクティビティ本文スニペット */}
         {isLink && activitySnippet && (
-          <blockquote className="rounded-lg border-l-2 border-violet-500/60 bg-zinc-900/60 px-3 py-2 text-xs text-zinc-400 line-clamp-2">
+          <blockquote
+            style={{
+              borderLeft: "2px solid var(--mf-accent)",
+              paddingLeft: 10,
+              margin: 0,
+              fontSize: 12,
+              color: "var(--mf-text-sub)",
+              lineHeight: 1.6,
+              overflow: "hidden",
+              display: "-webkit-box",
+              WebkitLineClamp: 2,
+              WebkitBoxOrient: "vertical",
+            }}
+          >
             {activitySnippet}
           </blockquote>
         )}
 
-        {/* 通知種別バッジ */}
-        <span className="self-start rounded-full bg-zinc-700/60 px-2 py-0.5 text-xs text-zinc-400">
+        <span
+          style={{
+            alignSelf: "flex-start",
+            padding: "2px 8px",
+            borderRadius: 999,
+            background: "var(--mf-surface-tint)",
+            fontSize: 11,
+            color: "var(--mf-text-muted)",
+            fontWeight: 600,
+          }}
+        >
           {isLink ? "🔗 リンク" : "📥 サブスク"}
         </span>
       </div>
@@ -85,62 +120,59 @@ const NotificationItem = ({
   );
 };
 
-// ─── NotificationList ──────────────────────────────────────────
-
-/**
- * 通知一覧コンポーネント（Client Component）。
- * notificationRepository から全通知を取得し、時系列降順で表示する。
- * リンク通知のアイテムをクリックすると DetailPanel に紐づくアクティビティを表示する。
- */
 const NotificationList = () => {
   const notifications = notificationRepository.listAll();
-
-  // ユーザー情報をマップ化
   const userMap = createLookupMap(userRepository.listAll(), (user) => user.id);
-
-  // アクティビティをマップ化（リンク通知のスニペット表示用）
   const activityMap = createLookupMap(activityRepository.listAll(), (activity) => activity.id);
 
   if (notifications.length === 0) {
     return (
-      <div className="flex flex-col items-center gap-4 py-20 text-center">
-        <p className="text-4xl">🔔</p>
-        <p className="text-sm text-zinc-400">まだ通知はありません</p>
+      <div
+        style={{
+          display: "flex",
+          flexDirection: "column",
+          alignItems: "center",
+          gap: 16,
+          padding: "80px 0",
+          textAlign: "center",
+        }}
+      >
+        <p style={{ fontSize: 36 }}>🔔</p>
+        <p style={{ fontSize: 13, color: "var(--mf-text-muted)" }}>
+          まだ通知はありません
+        </p>
       </div>
     );
   }
 
   return (
-    <ul className="flex flex-col gap-3">
+    <ul style={{ display: "flex", flexDirection: "column", gap: 10, listStyle: "none", padding: 0, margin: 0 }}>
       {notifications.map((notification) => {
         const fromUser = userMap.get(notification.fromUserId);
         if (!fromUser) return null;
 
         if (notification.type === "link") {
           const activity = activityMap.get(notification.activityId);
-          const detail = "あなたの投稿をリンクしました";
           return (
             <NotificationItem
               key={notification.id}
               notification={notification}
               fromUser={fromUser}
-              detail={detail}
+              detail="あなたの投稿をリンクしました"
               activitySnippet={activity?.body}
               activityId={notification.activityId}
             />
           );
         }
 
-        // subscribe
         const face = faceRepository.findById(notification.faceId);
         const faceName = face ? getFaceTitle(face) : notification.faceId;
-        const detail = `${faceName} をサブスクライブしました`;
         return (
           <NotificationItem
             key={notification.id}
             notification={notification}
             fromUser={fromUser}
-            detail={detail}
+            detail={`${faceName} をサブスクライブしました`}
           />
         );
       })}

--- a/src/components/search/SearchBar.tsx
+++ b/src/components/search/SearchBar.tsx
@@ -3,22 +3,43 @@ type SearchBarProps = {
   onChange: (value: string) => void;
 };
 
-/**
- * キーワード入力フィールド。
- * 入力のたびに onChange を呼び出し、親コンポーネントが状態を管理する。
- */
 const SearchBar = ({ value, onChange }: SearchBarProps) => {
   return (
-    <div className="relative">
-      <span className="pointer-events-none absolute inset-y-0 left-3 flex items-center text-zinc-500">
-        🔍
+    <div style={{ position: "relative" }}>
+      <span
+        style={{
+          position: "absolute",
+          top: "50%",
+          left: 12,
+          transform: "translateY(-50%)",
+          pointerEvents: "none",
+          display: "flex",
+          alignItems: "center",
+          color: "var(--mf-text-muted)",
+        }}
+      >
+        <svg width={15} height={15} viewBox="0 0 16 16" fill="none" stroke="currentColor" strokeWidth={1.8} strokeLinecap="round" strokeLinejoin="round">
+          <circle cx={7} cy={7} r={4.5} />
+          <path d="M10.5 10.5l3 3" />
+        </svg>
       </span>
       <input
         type="search"
         value={value}
         onChange={(e) => onChange(e.target.value)}
         placeholder="キーワードで検索..."
-        className="w-full rounded-xl border border-zinc-700 bg-zinc-800 py-2.5 pl-9 pr-4 text-sm text-zinc-100 placeholder:text-zinc-500 focus:border-violet-500 focus:outline-none focus:ring-1 focus:ring-violet-500"
+        style={{
+          width: "100%",
+          boxSizing: "border-box",
+          borderRadius: 12,
+          border: "0.5px solid var(--mf-line)",
+          background: "var(--mf-surface)",
+          padding: "10px 14px 10px 36px",
+          fontSize: 14,
+          color: "var(--mf-ink)",
+          fontFamily: "var(--mf-font-sans)",
+          outline: "none",
+        }}
       />
     </div>
   );

--- a/src/components/search/SearchClient.tsx
+++ b/src/components/search/SearchClient.tsx
@@ -41,24 +41,15 @@ const SearchClient = ({
     const lowerQuery = trimmedQuery.toLowerCase();
     const scopedActivities = allActivities.filter((activity) => {
       if (scope === "mine") return activity.userId === currentUserId;
-      if (scope === "subscribed") {
-        return subscribedFaceIds.includes(activity.faceId);
-      }
+      if (scope === "subscribed") return subscribedFaceIds.includes(activity.faceId);
       return true;
     });
 
     return scopedActivities.flatMap((activity) => {
-      if (!activity.body.toLowerCase().includes(lowerQuery)) {
-        return [];
-      }
-
+      if (!activity.body.toLowerCase().includes(lowerQuery)) return [];
       const user = userMap.get(activity.userId);
       const face = faceMap.get(activity.faceId);
-
-      if (!user || !face) {
-        return [];
-      }
-
+      if (!user || !face) return [];
       return [{ activity, user, face }];
     });
   }, [allActivities, currentUserId, faceMap, query, scope, subscribedFaceIds, userMap]);
@@ -66,27 +57,44 @@ const SearchClient = ({
   const faceResults = useMemo(() => {
     const trimmedQuery = query.trim();
     if (!trimmedQuery) return [];
-
     const lowerQuery = trimmedQuery.toLowerCase();
-
     return allFaces.filter(
       (face) =>
         face.name.toLowerCase().includes(lowerQuery) ||
-        (face.description ?? "").toLowerCase().includes(lowerQuery),
+        (face.description ?? "").toLowerCase().includes(lowerQuery)
     );
   }, [allFaces, query]);
 
   return (
-    <div className="flex flex-col">
-      <header className="sticky top-0 z-10 border-b border-zinc-800 bg-zinc-950/80 px-4 py-3 backdrop-blur-sm">
-        <h1 className="mb-3 text-lg font-bold text-zinc-100">検索</h1>
-        <div className="flex flex-col gap-2">
-          <SearchBar value={query} onChange={setQuery} />
-          <SearchScopeSelector scope={scope} onScopeChange={setScope} />
-        </div>
+    <div style={{ display: "flex", flexDirection: "column" }}>
+      <header
+        style={{
+          position: "sticky",
+          top: 0,
+          zIndex: 10,
+          background: "var(--mf-bg-light)",
+          borderBottom: "0.5px solid var(--mf-line)",
+          padding: "14px 20px",
+          display: "flex",
+          flexDirection: "column",
+          gap: 10,
+        }}
+      >
+        <h1
+          style={{
+            fontSize: 17,
+            fontWeight: 700,
+            color: "var(--mf-brand)",
+            margin: 0,
+          }}
+        >
+          検索
+        </h1>
+        <SearchBar value={query} onChange={setQuery} />
+        <SearchScopeSelector scope={scope} onScopeChange={setScope} />
       </header>
 
-      <main className="px-4 py-4">
+      <main style={{ padding: "16px 20px" }}>
         <SearchResults
           query={query.trim()}
           activityResults={activityResults}

--- a/src/components/search/SearchResults.tsx
+++ b/src/components/search/SearchResults.tsx
@@ -3,9 +3,9 @@
 import { type Activity } from "@/types/activity";
 import { type User } from "@/types/user";
 import { type Face } from "@/types/face";
-import ActivityCard from "@/components/ui/ActivityCard";
+import SeedRow from "@/components/ui/SeedRow";
+import FaceBadge from "@/components/ui/FaceBadge";
 import { getFaceTitle } from "@/lib/display";
-import { cn } from "@/lib/utils";
 import { useDetailPanel } from "@/lib/detail-panel-context";
 
 export type SearchActivityResultItem = {
@@ -21,12 +21,6 @@ type SearchResultsProps = {
   subscribedFaceIds: string[];
 };
 
-/**
- * 検索結果一覧。
- * - クエリ未入力: 検索促進メッセージを表示
- * - クエリあり・0件: 該当なしメッセージを表示
- * - クエリあり・N件: フェイス一覧 + アクティビティ一覧を表示
- */
 const SearchResults = ({
   query,
   activityResults,
@@ -34,15 +28,25 @@ const SearchResults = ({
   subscribedFaceIds,
 }: SearchResultsProps) => {
   const { state, openActivity, openFace } = useDetailPanel();
+
   if (!query) {
     return (
-      <div className="flex flex-col items-center gap-3 py-20 text-center">
-        <p className="text-3xl">🔍</p>
-        <p className="text-sm text-zinc-400">
+      <div
+        style={{
+          display: "flex",
+          flexDirection: "column",
+          alignItems: "center",
+          gap: 12,
+          padding: "80px 0",
+          textAlign: "center",
+        }}
+      >
+        <p style={{ fontSize: 32 }}>🔍</p>
+        <p style={{ fontSize: 13, color: "var(--mf-text-muted)" }}>
           キーワードを入力して検索してください
         </p>
-        <p className="text-xs text-zinc-600">
-          フェイス名・アクティビティ本文をスコープに応じて絞り込みます
+        <p style={{ fontSize: 11.5, color: "var(--mf-text-faint)" }}>
+          フェイス名・シード本文をスコープに応じて絞り込みます
         </p>
       </div>
     );
@@ -52,28 +56,45 @@ const SearchResults = ({
 
   if (totalCount === 0) {
     return (
-      <div className="flex flex-col items-center gap-3 py-20 text-center">
-        <p className="text-3xl">😶</p>
-        <p className="text-sm text-zinc-400">
+      <div
+        style={{
+          display: "flex",
+          flexDirection: "column",
+          alignItems: "center",
+          gap: 12,
+          padding: "80px 0",
+          textAlign: "center",
+        }}
+      >
+        <p style={{ fontSize: 32 }}>😶</p>
+        <p style={{ fontSize: 13, color: "var(--mf-text-muted)" }}>
           「{query}」に一致する結果が見つかりませんでした
-        </p>
-        <p className="text-xs text-zinc-600">
-          別のキーワードやスコープで試してみてください
         </p>
       </div>
     );
   }
 
   return (
-    <div className="flex flex-col gap-6">
-      {/* フェイス検索結果セクション */}
+    <div style={{ display: "flex", flexDirection: "column", gap: 24 }}>
+      {/* フェイス検索結果 */}
       {faceResults.length > 0 && (
-        <section className="flex flex-col gap-3">
-          <h2 className="text-xs font-semibold uppercase tracking-wider text-zinc-500">
+        <section>
+          <h2
+            style={{
+              fontSize: 10.5,
+              fontWeight: 700,
+              letterSpacing: 0.6,
+              textTransform: "uppercase",
+              color: "var(--mf-text-muted)",
+              marginBottom: 8,
+            }}
+          >
             フェイス
-            <span className="ml-2 text-violet-400">{faceResults.length}</span>
+            <span style={{ marginLeft: 6, color: "var(--mf-accent)", fontWeight: 700 }}>
+              {faceResults.length}
+            </span>
           </h2>
-          <ul className="flex flex-col gap-2">
+          <ul style={{ display: "flex", flexDirection: "column", gap: 6, listStyle: "none", padding: 0, margin: 0 }}>
             {faceResults.map((face) => {
               const isSubscribed = subscribedFaceIds.includes(face.id);
               const isSelected = state.type === "face" && state.faceId === face.id;
@@ -81,36 +102,69 @@ const SearchResults = ({
                 <li
                   key={face.id}
                   onClick={() => {
-                    if (window.innerWidth >= 768) openFace(face.id);
+                    if (typeof window !== "undefined" && window.innerWidth >= 768) {
+                      openFace(face.id);
+                    }
                   }}
-                  className={cn(
-                    "flex items-center justify-between gap-3 rounded-2xl bg-zinc-800/60 px-4 py-3 transition md:cursor-pointer",
-                    isSelected
-                      ? "ring-1 ring-violet-500/40 bg-zinc-800"
-                      : "hover:bg-zinc-800",
-                  )}
+                  style={{
+                    display: "flex",
+                    alignItems: "center",
+                    justifyContent: "space-between",
+                    gap: 12,
+                    padding: "12px 14px",
+                    borderRadius: 12,
+                    background: isSelected
+                      ? "rgba(30,42,74,0.06)"
+                      : "var(--mf-surface-card)",
+                    border: `0.5px solid ${isSelected ? "var(--mf-brand)" : "var(--mf-line)"}`,
+                    cursor: "pointer",
+                    transition: "background 0.15s",
+                  }}
                 >
-                  <div className="flex min-w-0 items-center gap-3">
-                    {face.emoji && (
-                      <span className="text-2xl">{face.emoji}</span>
-                    )}
-                    <div className="min-w-0">
-                      <p className="truncate text-sm font-semibold text-zinc-100">
-                        {face.name}
+                  <div style={{ display: "flex", alignItems: "center", gap: 10, minWidth: 0 }}>
+                    <FaceBadge face={face} size={36} radius={10} />
+                    <div style={{ minWidth: 0 }}>
+                      <p
+                        style={{
+                          fontSize: 13,
+                          fontWeight: 700,
+                          color: "var(--mf-brand)",
+                          overflow: "hidden",
+                          textOverflow: "ellipsis",
+                          whiteSpace: "nowrap",
+                          margin: 0,
+                        }}
+                      >
+                        {getFaceTitle(face)}
                       </p>
                       {face.description && (
-                        <p className="truncate text-xs text-zinc-400">
+                        <p
+                          style={{
+                            fontSize: 11.5,
+                            color: "var(--mf-text-muted)",
+                            overflow: "hidden",
+                            textOverflow: "ellipsis",
+                            whiteSpace: "nowrap",
+                            margin: "2px 0 0",
+                          }}
+                        >
                           {face.description}
                         </p>
                       )}
                     </div>
                   </div>
                   <button
-                    className={
-                      isSubscribed
-                        ? "shrink-0 rounded-full border border-violet-500 px-3 py-1 text-xs font-medium text-violet-400"
-                        : "shrink-0 rounded-full bg-violet-600 px-3 py-1 text-xs font-medium text-white hover:bg-violet-500"
-                    }
+                    style={{
+                      flexShrink: 0,
+                      padding: "6px 14px",
+                      borderRadius: 999,
+                      border: isSubscribed ? "1px solid var(--mf-brand)" : "none",
+                      background: isSubscribed ? "transparent" : "var(--mf-accent)",
+                      color: isSubscribed ? "var(--mf-brand)" : "#fff",
+                      fontSize: 12,
+                      fontWeight: 700,
+                      cursor: "not-allowed",
+                    }}
                     disabled
                     aria-label={
                       isSubscribed
@@ -127,26 +181,35 @@ const SearchResults = ({
         </section>
       )}
 
-      {/* アクティビティ検索結果セクション */}
+      {/* シード検索結果 */}
       {activityResults.length > 0 && (
-        <section className="flex flex-col gap-3">
-          <h2 className="text-xs font-semibold uppercase tracking-wider text-zinc-500">
-            アクティビティ
-            <span className="ml-2 text-violet-400">{activityResults.length}</span>
+        <section>
+          <h2
+            style={{
+              fontSize: 10.5,
+              fontWeight: 700,
+              letterSpacing: 0.6,
+              textTransform: "uppercase",
+              color: "var(--mf-text-muted)",
+              marginBottom: 8,
+            }}
+          >
+            シード
+            <span style={{ marginLeft: 6, color: "var(--mf-accent)", fontWeight: 700 }}>
+              {activityResults.length}
+            </span>
           </h2>
-          <ul className="flex flex-col gap-3">
-            {activityResults.map(({ activity, user, face }) => (
-              <li key={activity.id}>
-                <ActivityCard
-                  activity={activity}
-                  user={user}
-                  faceTitle={getFaceTitle(face)}
-                  faceId={face.id}
-                  onClick={() => openActivity(activity.id)}
-                />
-              </li>
+          <div>
+            {activityResults.map(({ activity, face }, i) => (
+              <SeedRow
+                key={activity.id}
+                activity={activity}
+                face={face}
+                onClick={() => openActivity(activity.id)}
+                noBorder={i === activityResults.length - 1}
+              />
             ))}
-          </ul>
+          </div>
         </section>
       )}
     </div>

--- a/src/components/search/SearchScopeSelector.tsx
+++ b/src/components/search/SearchScopeSelector.tsx
@@ -1,5 +1,3 @@
-import { cn } from "@/lib/utils";
-
 export type SearchScope = "all" | "mine" | "subscribed";
 
 type ScopeOption = {
@@ -10,7 +8,7 @@ type ScopeOption = {
 const SCOPE_OPTIONS: ScopeOption[] = [
   { value: "all", label: "全体" },
   { value: "mine", label: "自分" },
-  { value: "subscribed", label: "サブスクフェイス" },
+  { value: "subscribed", label: "サブスク" },
 ];
 
 type SearchScopeSelectorProps = {
@@ -18,26 +16,26 @@ type SearchScopeSelectorProps = {
   onScopeChange: (scope: SearchScope) => void;
 };
 
-/**
- * 検索スコープ切り替えタブ。
- * 「全体 / 自分 / サブスクフェイス」の 3 種類から選択する。
- */
-const SearchScopeSelector = ({
-  scope,
-  onScopeChange,
-}: SearchScopeSelectorProps) => {
+const SearchScopeSelector = ({ scope, onScopeChange }: SearchScopeSelectorProps) => {
   return (
-    <div className="flex gap-1 rounded-lg bg-zinc-800/60 p-1">
+    <div style={{ display: "flex", gap: 6 }}>
       {SCOPE_OPTIONS.map((option) => (
         <button
           key={option.value}
+          type="button"
           onClick={() => onScopeChange(option.value)}
-          className={cn(
-            "flex-1 rounded-md py-1.5 text-xs font-medium transition-colors",
-            scope === option.value
-              ? "bg-violet-600 text-white shadow-sm"
-              : "text-zinc-400 hover:text-zinc-200",
-          )}
+          style={{
+            padding: "5px 16px",
+            borderRadius: 999,
+            fontSize: 12,
+            fontWeight: scope === option.value ? 700 : 400,
+            background: scope === option.value ? "var(--mf-brand)" : "var(--mf-surface-tint)",
+            color: scope === option.value ? "#fff" : "var(--mf-text-sub)",
+            border: "none",
+            cursor: "pointer",
+            whiteSpace: "nowrap",
+            flexShrink: 0,
+          }}
         >
           {option.label}
         </button>

--- a/src/components/subscriptions/SubscriptionFeed.tsx
+++ b/src/components/subscriptions/SubscriptionFeed.tsx
@@ -1,81 +1,297 @@
 "use client";
 
+import { useState, useMemo } from "react";
 import Link from "next/link";
 import { activityRepository } from "@/repositories/activity-repository";
 import { faceRepository } from "@/repositories/face-repository";
 import { userRepository } from "@/repositories/user-repository";
 import { subscriptionRepository } from "@/repositories/subscription-repository";
 import SeedRow from "@/components/ui/SeedRow";
+import DateBar from "@/components/ui/DateBar";
+import FaceBadge from "@/components/ui/FaceBadge";
 import { useDetailPanel } from "@/lib/detail-panel-context";
-import { createLookupMap } from "@/lib/display";
+import { createLookupMap, getFaceTitle } from "@/lib/display";
+
+type Tab = "timeline" | "subscriptions";
 
 const SubscriptionFeed = () => {
   const { openActivity } = useDetailPanel();
+  const [activeTab, setActiveTab] = useState<Tab>("timeline");
 
   const subscribedFaceIds = subscriptionRepository.getSubscribedFaceIds();
   const subscribedActivities = activityRepository.listByFaceIds(subscribedFaceIds);
 
-  const faceMap = createLookupMap(
-    subscribedFaceIds.flatMap((faceId) => {
-      const face = faceRepository.findById(faceId);
-      return face ? [face] : [];
-    }),
-    (face) => face.id,
+  const subscribedFaces = useMemo(
+    () =>
+      subscribedFaceIds.flatMap((faceId) => {
+        const face = faceRepository.findById(faceId);
+        return face ? [face] : [];
+      }),
+    [subscribedFaceIds]
   );
-  const userMap = createLookupMap(userRepository.listAll(), (user) => user.id);
-  void userMap;
 
-  if (subscribedActivities.length === 0) {
-    return (
-      <div
-        style={{
-          display: "flex",
-          flexDirection: "column",
-          alignItems: "center",
-          gap: 16,
-          padding: "80px 0",
-          textAlign: "center",
-        }}
-      >
-        <p style={{ fontSize: 36 }}>🔔</p>
-        <p style={{ fontSize: 13, color: "var(--mf-text-muted)" }}>
-          まだサブスクしているフェイスがありません
-        </p>
-        <Link
-          href="/search"
-          style={{
-            padding: "8px 20px",
-            borderRadius: 999,
-            background: "var(--mf-accent)",
-            color: "#fff",
-            fontSize: 13,
-            fontWeight: 700,
-            textDecoration: "none",
-          }}
-        >
-          検索してフェイスを探す
-        </Link>
-      </div>
-    );
-  }
+  const faceMap = createLookupMap(subscribedFaces, (face) => face.id);
+  const userMap = createLookupMap(userRepository.listAll(), (user) => user.id);
+
+  // タイムラインを日付でグループ化
+  const grouped = useMemo(() => {
+    const groups: { dateKey: string; activities: typeof subscribedActivities }[] = [];
+    let lastKey = "";
+    for (const act of subscribedActivities) {
+      const dateKey = act.createdAt.slice(0, 10);
+      if (dateKey !== lastKey) {
+        groups.push({ dateKey, activities: [act] });
+        lastKey = dateKey;
+      } else {
+        groups[groups.length - 1].activities.push(act);
+      }
+    }
+    return groups;
+  }, [subscribedActivities]);
+
+  const TABS: { key: Tab; label: string }[] = [
+    { key: "timeline", label: "タイムライン" },
+    { key: "subscriptions", label: "サブスク一覧" },
+  ];
 
   return (
     <div>
-      {subscribedActivities.map((activity, i) => {
-        const face = faceMap.get(activity.faceId);
-        if (!face) return null;
-        return (
-          <SeedRow
-            key={activity.id}
-            activity={activity}
-            face={face}
-            onClick={() => openActivity(activity.id)}
-            noBorder={i === subscribedActivities.length - 1}
-          />
-        );
-      })}
+      {/* タブ */}
+      <div
+        style={{
+          display: "flex",
+          borderBottom: "0.5px solid var(--mf-line)",
+          position: "sticky",
+          top: 0,
+          zIndex: 10,
+          background: "var(--mf-bg-light)",
+        }}
+      >
+        {TABS.map(({ key, label }) => (
+          <button
+            key={key}
+            type="button"
+            onClick={() => setActiveTab(key)}
+            style={{
+              flex: 1,
+              padding: "13px 0",
+              fontSize: 13,
+              fontWeight: activeTab === key ? 700 : 400,
+              color: activeTab === key ? "var(--mf-brand)" : "var(--mf-text-muted)",
+              background: "none",
+              border: "none",
+              cursor: "pointer",
+              borderBottom: activeTab === key ? "2px solid var(--mf-accent)" : "2px solid transparent",
+              marginBottom: -0.5,
+            }}
+          >
+            {label}
+          </button>
+        ))}
+      </div>
+
+      {activeTab === "timeline" && (
+        <>
+          {/* サブスク中フェイスの横スクロール行 */}
+          {subscribedFaces.length > 0 && (
+            <div
+              style={{
+                padding: "12px 16px",
+                borderBottom: "0.5px solid var(--mf-line)",
+                overflowX: "auto",
+                display: "flex",
+                gap: 12,
+              }}
+              className="mf-scroll"
+            >
+              {subscribedFaces.map((face) => {
+                const hasUnread = subscribedActivities.some((a) => a.faceId === face.id);
+                return (
+                  <div
+                    key={face.id}
+                    style={{
+                      display: "flex",
+                      flexDirection: "column",
+                      alignItems: "center",
+                      gap: 5,
+                      flexShrink: 0,
+                    }}
+                  >
+                    <div
+                      style={{
+                        padding: 2,
+                        borderRadius: 13,
+                        background: hasUnread
+                          ? "linear-gradient(135deg, var(--mf-accent), var(--mf-accent-soft))"
+                          : "transparent",
+                        border: hasUnread ? "none" : "1.5px solid var(--mf-line)",
+                      }}
+                    >
+                      <FaceBadge face={face} size={44} radius={11} />
+                    </div>
+                    <span
+                      style={{
+                        fontSize: 9.5,
+                        color: "var(--mf-text-sub)",
+                        maxWidth: 50,
+                        overflow: "hidden",
+                        textOverflow: "ellipsis",
+                        whiteSpace: "nowrap",
+                        textAlign: "center",
+                      }}
+                    >
+                      {getFaceTitle(face)}
+                    </span>
+                  </div>
+                );
+              })}
+            </div>
+          )}
+
+          {/* タイムライン */}
+          {subscribedActivities.length === 0 ? (
+            <EmptyState />
+          ) : (
+            <div style={{ padding: "0 28px" }}>
+              {grouped.map(({ dateKey, activities: acts }) => (
+                <div key={dateKey}>
+                  <DateBar
+                    label={formatDateLabel(dateKey)}
+                    date={dateKey.replace(/-/g, "/")}
+                  />
+                  {acts.map((activity, i) => {
+                    const face = faceMap.get(activity.faceId);
+                    if (!face) return null;
+                    return (
+                      <SeedRow
+                        key={activity.id}
+                        activity={activity}
+                        face={face}
+                        onClick={() => openActivity(activity.id)}
+                        noBorder={i === acts.length - 1}
+                      />
+                    );
+                  })}
+                </div>
+              ))}
+            </div>
+          )}
+        </>
+      )}
+
+      {activeTab === "subscriptions" && (
+        <div style={{ padding: "16px 28px", display: "flex", flexDirection: "column", gap: 10 }}>
+          {subscribedFaces.length === 0 ? (
+            <EmptyState />
+          ) : (
+            subscribedFaces.map((face) => {
+              const owner = userMap.get(face.userId);
+              const faceActivities = subscribedActivities.filter((a) => a.faceId === face.id);
+              return (
+                <Link
+                  key={face.id}
+                  href={`/faces/${face.id}`}
+                  style={{
+                    display: "flex",
+                    alignItems: "center",
+                    gap: 12,
+                    padding: "12px 14px",
+                    borderRadius: 12,
+                    background: "var(--mf-surface-card)",
+                    border: "0.5px solid var(--mf-line)",
+                    textDecoration: "none",
+                  }}
+                >
+                  <FaceBadge face={face} size={40} radius={11} />
+                  <div style={{ flex: 1, minWidth: 0 }}>
+                    <div
+                      style={{
+                        fontSize: 13.5,
+                        fontWeight: 700,
+                        color: "var(--mf-brand)",
+                        overflow: "hidden",
+                        textOverflow: "ellipsis",
+                        whiteSpace: "nowrap",
+                      }}
+                    >
+                      {getFaceTitle(face)}
+                    </div>
+                    {owner && (
+                      <div style={{ fontSize: 11.5, color: "var(--mf-text-muted)", marginTop: 2 }}>
+                        {owner.name}
+                      </div>
+                    )}
+                  </div>
+                  <div
+                    style={{
+                      fontSize: 11,
+                      color: "var(--mf-text-muted)",
+                      textAlign: "right",
+                      flexShrink: 0,
+                    }}
+                  >
+                    {faceActivities.length} シード
+                  </div>
+                </Link>
+              );
+            })
+          )}
+        </div>
+      )}
     </div>
   );
+};
+
+const EmptyState = () => (
+  <div
+    style={{
+      margin: "32px 28px",
+      padding: "28px 20px",
+      borderRadius: 16,
+      background: "var(--mf-bg-dark)",
+      display: "flex",
+      flexDirection: "column",
+      alignItems: "center",
+      gap: 12,
+      textAlign: "center",
+    }}
+  >
+    <div
+      style={{
+        fontSize: 13,
+        fontWeight: 700,
+        color: "rgba(248,246,241,0.9)",
+        letterSpacing: 0.3,
+      }}
+    >
+      Quiet Feed
+    </div>
+    <p style={{ fontSize: 12, color: "rgba(248,246,241,0.5)", margin: 0, lineHeight: 1.7 }}>
+      まだサブスクしているフェイスがありません。
+      <br />
+      気になるフェイスを見つけて、フィードを育てましょう。
+    </p>
+    <Link
+      href="/search"
+      style={{
+        marginTop: 4,
+        padding: "8px 20px",
+        borderRadius: 999,
+        background: "var(--mf-accent)",
+        color: "#fff",
+        fontSize: 13,
+        fontWeight: 700,
+        textDecoration: "none",
+      }}
+    >
+      フェイスを探す
+    </Link>
+  </div>
+);
+
+const formatDateLabel = (dateKey: string): string => {
+  const [, m, d] = dateKey.split("-");
+  return `${parseInt(m, 10)}/${parseInt(d, 10)}`;
 };
 
 export default SubscriptionFeed;

--- a/src/components/subscriptions/SubscriptionFeed.tsx
+++ b/src/components/subscriptions/SubscriptionFeed.tsx
@@ -5,27 +5,16 @@ import { activityRepository } from "@/repositories/activity-repository";
 import { faceRepository } from "@/repositories/face-repository";
 import { userRepository } from "@/repositories/user-repository";
 import { subscriptionRepository } from "@/repositories/subscription-repository";
-import ActivityCard from "@/components/ui/ActivityCard";
+import SeedRow from "@/components/ui/SeedRow";
 import { useDetailPanel } from "@/lib/detail-panel-context";
-import { createLookupMap, getFaceTitle } from "@/lib/display";
+import { createLookupMap } from "@/lib/display";
 
-/**
- * サブスク画面フィード。
- * currentUser がサブスクライブしているフェイスのアクティビティを
- * 時系列降順（最新が先頭）で表示する。
- *
- * 各カードには「誰の・何のフェイスの投稿か」を明示する。
- */
 const SubscriptionFeed = () => {
   const { openActivity } = useDetailPanel();
 
-  // サブスクライブ中フェイスID一覧をリポジトリ経由で取得
   const subscribedFaceIds = subscriptionRepository.getSubscribedFaceIds();
-
-  // サブスクライブ中フェイスのアクティビティを新しい順に取得
   const subscribedActivities = activityRepository.listByFaceIds(subscribedFaceIds);
 
-  // O(1) で引けるようにマップ化
   const faceMap = createLookupMap(
     subscribedFaceIds.flatMap((faceId) => {
       const face = faceRepository.findById(faceId);
@@ -34,17 +23,35 @@ const SubscriptionFeed = () => {
     (face) => face.id,
   );
   const userMap = createLookupMap(userRepository.listAll(), (user) => user.id);
+  void userMap;
 
   if (subscribedActivities.length === 0) {
     return (
-      <div className="flex flex-col items-center gap-4 py-20 text-center">
-        <p className="text-4xl">🔔</p>
-        <p className="text-sm text-zinc-400">
+      <div
+        style={{
+          display: "flex",
+          flexDirection: "column",
+          alignItems: "center",
+          gap: 16,
+          padding: "80px 0",
+          textAlign: "center",
+        }}
+      >
+        <p style={{ fontSize: 36 }}>🔔</p>
+        <p style={{ fontSize: 13, color: "var(--mf-text-muted)" }}>
           まだサブスクしているフェイスがありません
         </p>
         <Link
           href="/search"
-          className="rounded-full bg-violet-600 px-5 py-2 text-sm font-semibold text-white transition hover:bg-violet-500 active:bg-violet-700"
+          style={{
+            padding: "8px 20px",
+            borderRadius: 999,
+            background: "var(--mf-accent)",
+            color: "#fff",
+            fontSize: 13,
+            fontWeight: 700,
+            textDecoration: "none",
+          }}
         >
           検索してフェイスを探す
         </Link>
@@ -53,24 +60,21 @@ const SubscriptionFeed = () => {
   }
 
   return (
-    <ul className="flex flex-col gap-3">
-      {subscribedActivities.map((activity) => {
+    <div>
+      {subscribedActivities.map((activity, i) => {
         const face = faceMap.get(activity.faceId);
-        const user = userMap.get(activity.userId);
-        if (!face || !user) return null;
+        if (!face) return null;
         return (
-          <li key={activity.id}>
-            <ActivityCard
-              activity={activity}
-              user={user}
-              faceTitle={getFaceTitle(face)}
-              faceId={face.id}
-              onClick={() => openActivity(activity.id)}
-            />
-          </li>
+          <SeedRow
+            key={activity.id}
+            activity={activity}
+            face={face}
+            onClick={() => openActivity(activity.id)}
+            noBorder={i === subscribedActivities.length - 1}
+          />
         );
       })}
-    </ul>
+    </div>
   );
 };
 

--- a/src/components/ui/ActivityCard.tsx
+++ b/src/components/ui/ActivityCard.tsx
@@ -5,10 +5,7 @@ import Image from "next/image";
 import Link from "next/link";
 import { type Activity } from "@/types/activity";
 import { type User } from "@/types/user";
-import Avatar from "./Avatar";
-import Badge from "./Badge";
 import FaceChip from "./FaceChip";
-import { cn } from "@/lib/utils";
 import { formatRelativeTime } from "@/lib/format-relative-time";
 import { useDetailPanel } from "@/lib/detail-panel-context";
 
@@ -16,12 +13,9 @@ type ActivityCardProps = {
   activity: Activity;
   user: User;
   faceTitle: string;
-  /** フェイスチップの色決定に使用 */
   faceId: string;
-  /** true のとき最初の画像を優先読み込み（LCP 対策） */
   priority?: boolean;
   className?: string;
-  /** クリック時のコールバック（DetailPanel 連携用） */
   onClick?: () => void;
 };
 
@@ -33,11 +27,11 @@ const ActivityCard = ({
   faceTitle,
   faceId,
   priority = false,
-  className,
   onClick,
 }: ActivityCardProps) => {
   const { state } = useDetailPanel();
-  const isSelected = state.type === "activity" && state.activityId === activity.id;
+  const isSelected =
+    state.type === "activity" && state.activityId === activity.id;
 
   const isLong = activity.body.length > COLLAPSE_THRESHOLD;
   const [expanded, setExpanded] = useState(false);
@@ -47,14 +41,8 @@ const ActivityCard = ({
       ? activity.body.slice(0, COLLAPSE_THRESHOLD) + "…"
       : activity.body;
 
-  const canOpenDetail = Boolean(onClick);
-
-  const isDesktopViewport = () => {
-    return typeof window !== "undefined" && window.innerWidth >= 768;
-  };
-
   const handleCardClick = () => {
-    if (onClick && isDesktopViewport()) {
+    if (onClick && typeof window !== "undefined" && window.innerWidth >= 768) {
       onClick();
     }
   };
@@ -65,7 +53,7 @@ const ActivityCard = ({
       role={onClick ? "button" : undefined}
       tabIndex={onClick ? 0 : undefined}
       onKeyDown={
-        canOpenDetail
+        onClick
           ? (e) => {
               if (e.key === "Enter" || e.key === " ") {
                 e.preventDefault();
@@ -74,36 +62,44 @@ const ActivityCard = ({
             }
           : undefined
       }
-      className={cn(
-        "flex flex-col gap-3 rounded-2xl p-4 transition duration-200",
-        // 基本スタイル（通常時のホバー等のアニメーション）
-        !isSelected && "bg-zinc-800/60 hover:bg-zinc-800 hover:scale-[1.01] active:scale-[0.99]",
-        // PCクリック用
-        canOpenDetail && "md:cursor-pointer",
-        // 選択時スタイル: 【3. 背景全体を薄い紫に】
-        isSelected && "bg-violet-950/60 scale-[1.01]",
-        className,
-      )}
+      style={{
+        display: "flex",
+        flexDirection: "column",
+        gap: 10,
+        borderRadius: 14,
+        padding: "14px 16px",
+        background: isSelected ? "rgba(30,42,74,0.06)" : "var(--mf-surface-card)",
+        border: `0.5px solid ${isSelected ? "var(--mf-brand)" : "var(--mf-line)"}`,
+        transition: "background 0.15s, border 0.15s",
+        cursor: onClick ? "pointer" : undefined,
+      }}
     >
-      {/* ヘッダー: アバター・名前・バッジ・フェイス・日時 */}
-      <div className="flex items-start gap-3">
-        <Avatar src={user.avatarUrl} alt={user.name} size="md" />
-        <div className="flex flex-1 flex-col gap-0.5 overflow-hidden">
-          <div className="flex items-center gap-1.5 text-sm font-semibold text-zinc-100">
-            <span className="truncate">{user.name}</span>
-            {user.badge && <Badge emoji={user.badge} />}
+      {/* ヘッダー */}
+      <div style={{ display: "flex", alignItems: "flex-start", gap: 10 }}>
+        <div style={{ flex: 1, minWidth: 0, display: "flex", flexDirection: "column", gap: 4 }}>
+          <div
+            style={{
+              fontSize: 13.5,
+              fontWeight: 700,
+              color: "var(--mf-brand)",
+              overflow: "hidden",
+              textOverflow: "ellipsis",
+              whiteSpace: "nowrap",
+            }}
+          >
+            {user.name}
           </div>
-          <div className="flex items-center gap-2">
-            <Link href={`/faces/${faceId}`} onClick={(e) => e.stopPropagation()}>
-              <FaceChip
-                title={faceTitle}
-                faceId={faceId}
-                className="transition-opacity hover:opacity-80"
-              />
+          <div style={{ display: "flex", alignItems: "center", gap: 8 }}>
+            <Link
+              href={`/faces/${faceId}`}
+              onClick={(e) => e.stopPropagation()}
+              style={{ textDecoration: "none" }}
+            >
+              <FaceChip title={faceTitle} faceId={faceId} />
             </Link>
             <time
               dateTime={activity.createdAt}
-              className="text-xs text-zinc-500"
+              style={{ fontSize: 11.5, color: "var(--mf-text-muted)" }}
             >
               {formatRelativeTime(activity.createdAt)}
             </time>
@@ -112,34 +108,59 @@ const ActivityCard = ({
       </div>
 
       {/* 本文 */}
-      <div className="text-sm leading-relaxed text-zinc-200 whitespace-pre-wrap">
+      <div
+        style={{
+          fontSize: 14,
+          lineHeight: 1.65,
+          color: "var(--mf-ink)",
+          whiteSpace: "pre-wrap",
+        }}
+      >
         {displayBody}
       </div>
 
-      {/* 「もっと見る」 */}
       {isLong && (
         <button
           type="button"
           onClick={(e) => {
-              e.stopPropagation();
-              setExpanded((prev) => !prev);
-            }}
-          className="self-start text-xs font-medium text-violet-400 hover:text-violet-300 transition-colors"
+            e.stopPropagation();
+            setExpanded((prev) => !prev);
+          }}
+          style={{
+            alignSelf: "flex-start",
+            fontSize: 12.5,
+            fontWeight: 600,
+            color: "var(--mf-accent)",
+            background: "none",
+            border: "none",
+            padding: 0,
+            cursor: "pointer",
+          }}
         >
-          {expanded ? "折りたたむ" : "もっと見る"}
+          {expanded ? "折りたたむ" : "続きを読む"}
         </button>
       )}
 
       {/* 画像 */}
       {activity.imageUrls && activity.imageUrls.length > 0 && (
         <div
-          className={cn(
-            "grid gap-1.5 overflow-hidden rounded-xl",
-            activity.imageUrls.length === 1 ? "grid-cols-1" : "grid-cols-2",
-          )}
+          style={{
+            display: "grid",
+            gridTemplateColumns: `repeat(${Math.min(activity.imageUrls.length, 2)}, 1fr)`,
+            gap: 3,
+            borderRadius: 12,
+            overflow: "hidden",
+            border: "0.5px solid var(--mf-line-soft)",
+          }}
         >
           {activity.imageUrls.map((url, i) => (
-            <div key={i} className="relative aspect-video w-full overflow-hidden rounded-lg">
+            <div
+              key={i}
+              style={{
+                position: "relative",
+                aspectRatio: activity.imageUrls!.length === 1 ? "16/10" : "1/1",
+              }}
+            >
               <Image
                 src={url}
                 alt={`画像 ${i + 1}`}

--- a/src/components/ui/ActivityDetail.tsx
+++ b/src/components/ui/ActivityDetail.tsx
@@ -2,16 +2,13 @@
 
 import Image from "next/image";
 import Link from "next/link";
-import { X } from "lucide-react";
 import { activityRepository } from "@/repositories/activity-repository";
 import { faceRepository } from "@/repositories/face-repository";
 import { userRepository } from "@/repositories/user-repository";
 import { useDetailPanel } from "@/lib/detail-panel-context";
 import { getFaceTitle } from "@/lib/display";
-import Avatar from "./Avatar";
-import Badge from "./Badge";
+import FaceBadge from "./FaceBadge";
 import FaceChip from "./FaceChip";
-import { cn } from "@/lib/utils";
 import { formatRelativeTime } from "@/lib/format-relative-time";
 
 type ActivityDetailProps = {
@@ -27,78 +24,145 @@ const ActivityDetail = ({ activityId }: ActivityDetailProps) => {
 
   if (!activity || !user) {
     return (
-      <div className="flex flex-col h-full">
-        <div className="sticky top-0 flex items-center justify-between border-b border-zinc-800 bg-zinc-950/80 px-4 py-3 backdrop-blur-sm">
-          <h2 className="text-sm font-semibold text-zinc-400">アクティビティ詳細</h2>
+      <div style={{ display: "flex", flexDirection: "column", height: "100%" }}>
+        <div
+          style={{
+            display: "flex",
+            alignItems: "center",
+            justifyContent: "space-between",
+            padding: "14px 16px",
+            borderBottom: "0.5px solid var(--mf-line)",
+            background: "rgba(248,246,241,0.85)",
+            backdropFilter: "blur(10px)",
+          }}
+        >
+          <span style={{ fontSize: 13, fontWeight: 700, color: "var(--mf-brand)" }}>
+            シード詳細
+          </span>
           <button
             type="button"
             aria-label="閉じる"
             onClick={close}
-            className="flex h-8 w-8 items-center justify-center rounded-full text-zinc-400 hover:bg-zinc-800 hover:text-zinc-100"
+            style={{
+              width: 28, height: 28, display: "flex", alignItems: "center", justifyContent: "center",
+              borderRadius: "50%", border: "none", background: "transparent",
+              color: "var(--mf-text-muted)", cursor: "pointer",
+            }}
           >
-            <X size={16} />
+            <svg width={16} height={16} viewBox="0 0 20 20" fill="none" stroke="currentColor" strokeWidth={1.6} strokeLinecap="round">
+              <path d="M5 5l10 10M15 5L5 15" />
+            </svg>
           </button>
         </div>
-        <div className="flex flex-col items-center justify-center h-full gap-3 px-8 text-center">
-          <p className="text-sm text-zinc-600">アクティビティが見つかりませんでした</p>
+        <div style={{ display: "flex", alignItems: "center", justifyContent: "center", flex: 1, padding: "32px 16px" }}>
+          <p style={{ fontSize: 13, color: "var(--mf-text-muted)" }}>シードが見つかりませんでした</p>
         </div>
       </div>
     );
   }
 
-  const resolvedFaceTitle = face ? getFaceTitle(face) : "";
-  const faceTitle = resolvedFaceTitle || activity.faceId || "不明なフェイス";
+  const faceTitle = face ? getFaceTitle(face) : activity.faceId || "不明なフェイス";
   const relativeTime = formatRelativeTime(activity.createdAt);
 
   return (
-    <div className="flex flex-col h-full">
+    <div style={{ display: "flex", flexDirection: "column", height: "100%" }}>
       {/* ヘッダー */}
-      <div className="sticky top-0 flex items-center justify-between border-b border-zinc-800 bg-zinc-950/80 px-4 py-3 backdrop-blur-sm">
-        <h2 className="text-sm font-semibold text-zinc-400">アクティビティ詳細</h2>
+      <div
+        style={{
+          display: "flex",
+          alignItems: "center",
+          justifyContent: "space-between",
+          padding: "14px 16px",
+          borderBottom: "0.5px solid var(--mf-line)",
+          background: "rgba(248,246,241,0.85)",
+          backdropFilter: "blur(10px)",
+          position: "sticky",
+          top: 0,
+          zIndex: 1,
+        }}
+      >
+        <span style={{ fontSize: 13, fontWeight: 700, color: "var(--mf-brand)" }}>
+          シード詳細
+        </span>
         <button
           type="button"
           aria-label="閉じる"
           onClick={close}
-          className="flex h-8 w-8 items-center justify-center rounded-full text-zinc-400 hover:bg-zinc-800 hover:text-zinc-100"
+          style={{
+            width: 28, height: 28, display: "flex", alignItems: "center", justifyContent: "center",
+            borderRadius: "50%", border: "none", background: "transparent",
+            color: "var(--mf-text-muted)", cursor: "pointer",
+          }}
         >
-          <X size={16} />
+          <svg width={16} height={16} viewBox="0 0 20 20" fill="none" stroke="currentColor" strokeWidth={1.6} strokeLinecap="round">
+            <path d="M5 5l10 10M15 5L5 15" />
+          </svg>
         </button>
       </div>
 
       {/* コンテンツ */}
-      <div className="px-4 py-4 flex flex-col gap-4 overflow-y-auto">
+      <div style={{ padding: "16px", display: "flex", flexDirection: "column", gap: 16, overflowY: "auto" }}>
         {/* ユーザー・フェイス行 */}
-        <div className="flex items-start gap-3">
-          <Avatar src={user.avatarUrl} alt={user.name} size="md" />
-          <div className="flex flex-col gap-0.5">
-            <div className="flex items-center gap-1.5 text-sm font-semibold text-zinc-100">
-              <span>{user.name}</span>
-              {user.badge && <Badge emoji={user.badge} />}
-            </div>
-            <div className="flex items-center gap-2">
+        <div style={{ display: "flex", alignItems: "flex-start", gap: 12 }}>
+          {face ? (
+            <FaceBadge face={face} size={40} radius={11} />
+          ) : (
+            <div style={{
+              width: 40, height: 40, borderRadius: 11,
+              background: "var(--mf-surface-tint)",
+              display: "flex", alignItems: "center", justifyContent: "center",
+              fontSize: 18, flexShrink: 0,
+            }}>?</div>
+          )}
+          <div style={{ display: "flex", flexDirection: "column", gap: 4 }}>
+            <span style={{ fontSize: 13.5, fontWeight: 700, color: "var(--mf-brand)" }}>
+              {user.name}
+            </span>
+            <div style={{ display: "flex", alignItems: "center", gap: 8 }}>
               <FaceChip title={faceTitle} faceId={activity.faceId} />
-              <time dateTime={activity.createdAt} className="text-xs text-zinc-500">
+              <time
+                dateTime={activity.createdAt}
+                style={{ fontSize: 11.5, color: "var(--mf-text-muted)" }}
+              >
                 {relativeTime}
               </time>
             </div>
           </div>
         </div>
 
-        {/* 本文（全文展開・折りたたみなし） */}
-        <p className="text-sm leading-relaxed text-zinc-200 whitespace-pre-wrap">
+        {/* 本文 */}
+        <p
+          style={{
+            fontSize: 14,
+            lineHeight: 1.75,
+            color: "var(--mf-ink)",
+            whiteSpace: "pre-wrap",
+            margin: 0,
+          }}
+        >
           {activity.body}
         </p>
 
         {/* 画像グリッド */}
         {activity.imageUrls && activity.imageUrls.length > 0 && (
           <div
-            className={cn(
-              "grid gap-1.5 overflow-hidden rounded-xl",
-              activity.imageUrls.length === 1 ? "grid-cols-1" : "grid-cols-2",
-            )}
+            style={{
+              display: "grid",
+              gridTemplateColumns: `repeat(${Math.min(activity.imageUrls.length, 2)}, 1fr)`,
+              gap: 3,
+              borderRadius: 14,
+              overflow: "hidden",
+              border: "0.5px solid var(--mf-line-soft)",
+            }}
           >
             {activity.imageUrls.map((url, i) => (
-              <div key={i} className="relative aspect-video w-full overflow-hidden rounded-lg">
+              <div
+                key={i}
+                style={{
+                  position: "relative",
+                  aspectRatio: activity.imageUrls!.length === 1 ? "16/10" : "1/1",
+                }}
+              >
                 <Image
                   src={url}
                   alt={`画像 ${i + 1}`}
@@ -114,7 +178,12 @@ const ActivityDetail = ({ activityId }: ActivityDetailProps) => {
         {/* フェイスへのリンク */}
         <Link
           href={`/faces/${activity.faceId}`}
-          className="mt-2 self-start text-xs text-violet-400 hover:text-violet-300 transition-colors"
+          style={{
+            fontSize: 12,
+            color: "var(--mf-accent)",
+            fontWeight: 600,
+            textDecoration: "none",
+          }}
         >
           → このフェイスを見る
         </Link>

--- a/src/components/ui/AppHeader.tsx
+++ b/src/components/ui/AppHeader.tsx
@@ -1,0 +1,74 @@
+"use client";
+
+import Link from "next/link";
+import Wordmark from "@/components/ui/Wordmark";
+import { userRepository } from "@/repositories/user-repository";
+import { notificationRepository } from "@/repositories/notification-repository";
+
+const AppHeader = () => {
+  const user = userRepository.getCurrentUser();
+  const notifCount = notificationRepository.listAll().length;
+
+  return (
+    <header
+      className="md:hidden flex items-center justify-between shrink-0"
+      style={{
+        height: 52,
+        padding: "0 18px",
+        background: "var(--mf-bg-light)",
+        borderBottom: "0.5px solid var(--mf-line)",
+      }}
+    >
+      <Wordmark size={19} />
+
+      <div style={{ display: "flex", alignItems: "center", gap: 12 }}>
+        {/* 通知ベルアイコン */}
+        <Link
+          href="/notifications"
+          style={{ position: "relative", width: 36, height: 36, display: "flex", alignItems: "center", justifyContent: "center" }}
+          aria-label="通知"
+        >
+          <svg width={20} height={20} viewBox="0 0 20 20" fill="none" stroke="var(--mf-brand)" strokeWidth={1.6} strokeLinecap="round" strokeLinejoin="round">
+            <path d="M4.5 14.5h11l-1.3-1.7c-.5-.7-.8-1.5-.8-2.3V7.8a3.4 3.4 0 00-6.8 0v2.7c0 .8-.3 1.6-.8 2.3l-1.3 1.7z" />
+            <path d="M8.5 16.5a1.5 1.5 0 003 0" />
+          </svg>
+          {notifCount > 0 && (
+            <span
+              style={{
+                position: "absolute",
+                top: 9,
+                right: 9,
+                width: 7,
+                height: 7,
+                borderRadius: "50%",
+                background: "var(--mf-accent)",
+                boxShadow: "0 0 0 2px var(--mf-bg-light)",
+              }}
+            />
+          )}
+        </Link>
+
+        {/* アバター */}
+        <div
+          style={{
+            width: 30,
+            height: 30,
+            borderRadius: "50%",
+            background: "var(--mf-brand)",
+            color: "#F8F6F1",
+            display: "flex",
+            alignItems: "center",
+            justifyContent: "center",
+            fontSize: 12,
+            fontWeight: 700,
+            flexShrink: 0,
+          }}
+        >
+          {user.name.slice(0, 1)}
+        </div>
+      </div>
+    </header>
+  );
+};
+
+export default AppHeader;

--- a/src/components/ui/BottomNav.tsx
+++ b/src/components/ui/BottomNav.tsx
@@ -2,72 +2,108 @@
 
 import Link from "next/link";
 import { usePathname } from "next/navigation";
-import { Home, Bell, Search, Rss, Layers, type LucideIcon } from "lucide-react";
-import { cn } from "@/lib/utils";
 
 type NavItem = {
   href: string;
   label: string;
-  icon: LucideIcon;
+  icon: (active: boolean) => React.ReactNode;
 };
 
+const PencilIcon = ({ active }: { active: boolean }) => (
+  <svg width={22} height={22} viewBox="0 0 20 20" fill="none" stroke="currentColor" strokeWidth={1.6} strokeLinecap="round" strokeLinejoin="round">
+    {active ? (
+      <path d="M3 17l1-3.5L13 4.5l3.5 3.5L7.5 17H3z" fill="currentColor" />
+    ) : (
+      <>
+        <path d="M3 17l1-3.5L13 4.5l3.5 3.5L7.5 17H3z" />
+        <path d="M12 5.5l3.5 3.5" />
+      </>
+    )}
+  </svg>
+);
+
+const LayersIcon = ({ active }: { active: boolean }) => (
+  <svg width={22} height={22} viewBox="0 0 22 22" fill="none" stroke="currentColor" strokeWidth={1.6} strokeLinecap="round" strokeLinejoin="round">
+    <path d="M11 3L3 7l8 4 8-4-8-4z" fill={active ? "currentColor" : "none"} />
+    <path d="M3 11l8 4 8-4" opacity={active ? 0.6 : 1} />
+    {!active && <path d="M3 15l8 4 8-4" />}
+  </svg>
+);
+
+const CompassIcon = ({ active }: { active: boolean }) => (
+  <svg width={22} height={22} viewBox="0 0 22 22" fill="none">
+    <circle cx={11} cy={11} r={8} fill={active ? "currentColor" : "none"} fillOpacity={active ? 0.18 : 0} stroke="currentColor" strokeWidth={1.6} />
+    <path d="M14.5 7.5L12.5 12.5 7.5 14.5 9.5 9.5z" fill="currentColor" />
+  </svg>
+);
+
 const NAV_ITEMS: NavItem[] = [
-  { href: "/faces", label: "フェイス", icon: Layers },
-  { href: "/", label: "ホーム", icon: Home },
-  { href: "/subscriptions", label: "サブスク", icon: Rss },
-  { href: "/notifications", label: "通知", icon: Bell },
-  { href: "/search", label: "検索", icon: Search },
+  {
+    href: "/",
+    label: "Writing",
+    icon: (active) => <PencilIcon active={active} />,
+  },
+  {
+    href: "/faces",
+    label: "Reflection",
+    icon: (active) => <LayersIcon active={active} />,
+  },
+  {
+    href: "/subscriptions",
+    label: "Collection",
+    icon: (active) => <CompassIcon active={active} />,
+  },
 ];
 
 const BottomNav = () => {
   const pathname = usePathname();
 
   return (
-    <nav className="md:hidden fixed bottom-0 left-0 right-0 z-50 flex justify-center border-t border-zinc-700/60 bg-zinc-900/95 backdrop-blur-sm">
-      <ul className="flex w-full max-w-sm items-center">
-        {NAV_ITEMS.map((item) => {
-          const isActive =
-            item.href === "/"
-              ? pathname === "/"
-              : pathname === item.href || pathname.startsWith(item.href + "/");
-          const Icon = item.icon;
-          return (
-            <li key={item.href} className="flex-1">
-              <Link
-                href={item.href}
-                className={cn(
-                  "flex flex-col items-center py-2 transition-colors duration-200",
-                  isActive
-                    ? "text-violet-400"
-                    : "text-zinc-500 hover:text-zinc-300",
-                )}
-              >
-                {/* アクティブインジケーター：背景ピル */}
-                <span
-                  className={cn(
-                    "flex flex-col items-center gap-0.5 rounded-xl px-3 py-1.5 text-xs font-medium transition-all duration-200",
-                    isActive
-                      ? "bg-violet-500/20"
-                      : "bg-transparent",
-                  )}
-                >
-                  <Icon
-                    size={22}
-                    strokeWidth={isActive ? 2.5 : 2}
-                    className={cn(
-                      "transition-all duration-200",
-                      isActive && "[&>*]:fill-current",
-                    )}
-                  />
-                  <span className="whitespace-nowrap transition-all duration-200">
-                    {item.label}
-                  </span>
-                </span>
-              </Link>
-            </li>
-          );
-        })}
-      </ul>
+    <nav
+      className="md:hidden fixed bottom-0 left-0 right-0 z-50 flex justify-around items-center"
+      style={{
+        paddingBottom: 26,
+        paddingTop: 10,
+        background: "rgba(248,246,241,0.92)",
+        backdropFilter: "blur(20px) saturate(180%)",
+        WebkitBackdropFilter: "blur(20px) saturate(180%)",
+        borderTop: "0.5px solid var(--mf-line)",
+      }}
+    >
+      {NAV_ITEMS.map((item) => {
+        const isActive =
+          item.href === "/"
+            ? pathname === "/"
+            : pathname === item.href || pathname.startsWith(item.href + "/");
+
+        return (
+          <Link
+            key={item.href}
+            href={item.href}
+            style={{
+              display: "flex",
+              flexDirection: "column",
+              alignItems: "center",
+              gap: 3,
+              padding: "0 14px",
+              color: isActive ? "var(--mf-brand)" : "var(--mf-text-muted)",
+              textDecoration: "none",
+            }}
+          >
+            {item.icon(isActive)}
+            <span
+              style={{
+                fontFamily: "var(--mf-font-sans)",
+                fontSize: 10.5,
+                fontWeight: isActive ? 700 : 500,
+                letterSpacing: 0.4,
+              }}
+            >
+              {item.label}
+            </span>
+          </Link>
+        );
+      })}
     </nav>
   );
 };

--- a/src/components/ui/ContextRail.tsx
+++ b/src/components/ui/ContextRail.tsx
@@ -1,129 +1,370 @@
 "use client";
 
+import Link from "next/link";
 import { usePathname } from "next/navigation";
 import { useDetailPanel } from "@/lib/detail-panel-context";
+import { activityRepository } from "@/repositories/activity-repository";
+import { faceRepository } from "@/repositories/face-repository";
+import { userRepository } from "@/repositories/user-repository";
+import { subscriptionRepository } from "@/repositories/subscription-repository";
+import { getFaceTitle } from "@/lib/display";
+import { formatRelativeTime } from "@/lib/format-relative-time";
+import type { Face } from "@/types/face";
 import ActivityDetail from "./ActivityDetail";
 import FaceDetail from "./FaceDetail";
+import FaceBadge from "./FaceBadge";
 import RailCard from "./RailCard";
+import SeedRow from "./SeedRow";
 
-const WritingRail = () => (
-  <div style={{ display: "flex", flexDirection: "column", gap: 14 }}>
-    <RailCard title="On This Day">
-      <p
-        style={{
-          fontSize: 13,
-          lineHeight: 1.7,
-          color: "var(--mf-ink)",
-          margin: 0,
-        }}
-      >
-        過去のシードは、今のあなたに何を語りかけますか。
-      </p>
-    </RailCard>
-    <RailCard title="今月の記録">
-      <div style={{ display: "flex", gap: 18 }}>
-        {[
-          { n: "—", l: "シード" },
-          { n: "—", l: "日連続" },
-          { n: "—", l: "フェイス" },
-        ].map((s) => (
-          <div key={s.l} style={{ textAlign: "center" }}>
-            <div
-              style={{
-                fontSize: 22,
-                fontWeight: 700,
-                color: "var(--mf-brand)",
-                fontFamily: "var(--mf-font-serif-en)",
-              }}
-            >
-              {s.n}
+const REFERENCE_DATE = new Date("2026-04-01");
+
+// ── WritingRail ────────────────────────────────────────────────
+const WritingRail = () => {
+  const user = userRepository.getCurrentUser();
+  const allActivities = activityRepository.listByUserId(user.id);
+
+  const thisMonth = REFERENCE_DATE.toISOString().slice(0, 7); // "2026-04"
+  const monthlyActs = allActivities.filter((a) => a.createdAt.startsWith(thisMonth));
+  const monthlySeeds = monthlyActs.length;
+  const monthlyFaces = new Set(monthlyActs.map((a) => a.faceId)).size;
+
+  // ストリーク: REFERENCE_DATE から過去に向かって連続投稿日数を数える
+  const dateSet = new Set(allActivities.map((a) => a.createdAt.slice(0, 10)));
+  let streak = 0;
+  const cur = new Date(REFERENCE_DATE);
+  while (dateSet.has(cur.toISOString().slice(0, 10))) {
+    streak++;
+    cur.setDate(cur.getDate() - 1);
+  }
+
+  return (
+    <div style={{ display: "flex", flexDirection: "column", gap: 14 }}>
+      <RailCard title="今月の記録">
+        <div style={{ display: "flex", gap: 18 }}>
+          {[
+            { n: String(monthlySeeds), l: "シード" },
+            { n: String(streak), l: "日連続" },
+            { n: String(monthlyFaces), l: "フェイス" },
+          ].map((s) => (
+            <div key={s.l} style={{ textAlign: "center" }}>
+              <div
+                style={{
+                  fontSize: 22,
+                  fontWeight: 700,
+                  color: "var(--mf-brand)",
+                  fontFamily: "var(--mf-font-serif-en)",
+                }}
+              >
+                {s.n}
+              </div>
+              <div
+                style={{
+                  fontSize: 11,
+                  color: "var(--mf-text-muted)",
+                  marginTop: 2,
+                }}
+              >
+                {s.l}
+              </div>
             </div>
-            <div
-              style={{
-                fontSize: 11,
-                color: "var(--mf-text-muted)",
-                marginTop: 2,
-              }}
-            >
-              {s.l}
-            </div>
-          </div>
-        ))}
-      </div>
-    </RailCard>
-    <RailCard pad="14px">
-      <div
-        style={{
-          display: "flex",
-          alignItems: "center",
-          gap: 10,
-          color: "var(--mf-text-muted)",
-          fontSize: 13,
-        }}
-      >
-        <svg width={18} height={18} viewBox="0 0 18 18" fill="none" stroke="currentColor" strokeWidth={1.6} strokeLinecap="round" strokeLinejoin="round">
-          <circle cx={8} cy={8} r={5.5} />
-          <path d="M12.2 12.2L16 16" />
-        </svg>
-        すべてを検索
+          ))}
+        </div>
+      </RailCard>
+
+      <RailCard pad="14px">
         <div
           style={{
-            marginLeft: "auto",
-            fontSize: 10.5,
-            padding: "2px 6px",
-            background: "var(--mf-surface-tint)",
-            borderRadius: 4,
-            color: "var(--mf-text-sub)",
-            fontWeight: 700,
+            display: "flex",
+            alignItems: "center",
+            gap: 10,
+            color: "var(--mf-text-muted)",
+            fontSize: 13,
           }}
         >
-          ⌘K
+          <svg width={18} height={18} viewBox="0 0 18 18" fill="none" stroke="currentColor" strokeWidth={1.6} strokeLinecap="round" strokeLinejoin="round">
+            <circle cx={8} cy={8} r={5.5} />
+            <path d="M12.2 12.2L16 16" />
+          </svg>
+          すべてを検索
+          <div
+            style={{
+              marginLeft: "auto",
+              fontSize: 10.5,
+              padding: "2px 6px",
+              background: "var(--mf-surface-tint)",
+              borderRadius: 4,
+              color: "var(--mf-text-sub)",
+              fontWeight: 700,
+            }}
+          >
+            ⌘K
+          </div>
         </div>
-      </div>
-    </RailCard>
-  </div>
-);
+      </RailCard>
+    </div>
+  );
+};
 
-const ReflectionRail = () => (
-  <div style={{ display: "flex", flexDirection: "column", gap: 14 }}>
-    <RailCard title="フェイスについて">
-      <p
-        style={{
-          fontSize: 12.5,
-          lineHeight: 1.75,
-          color: "var(--mf-text-sub)",
-          margin: 0,
-        }}
-      >
-        フェイスは「あなたの多面性」のひとつ。投稿したい内容にあったフェイスで書き、後から自分のために振り返ることができます。
-      </p>
-    </RailCard>
-  </div>
-);
+// ── ReflectionRail ─────────────────────────────────────────────
+const ReflectionRail = () => {
+  const user = userRepository.getCurrentUser();
+  const faces = faceRepository.listByUserId(user.id);
+  const allActivities = activityRepository.listByUserId(user.id);
 
-const CollectionRail = () => (
-  <div style={{ display: "flex", flexDirection: "column", gap: 14 }}>
-    <RailCard title="サブスク中">
-      <p
-        style={{
-          fontSize: 12.5,
-          lineHeight: 1.75,
-          color: "var(--mf-text-sub)",
-          margin: 0,
-        }}
-      >
-        サブスクライブしているフェイスの新着シードがここに表示されます。
-      </p>
-    </RailCard>
-  </div>
-);
+  const refKey = REFERENCE_DATE.toISOString().slice(0, 10);
+  const weekAgo = new Date(REFERENCE_DATE);
+  weekAgo.setDate(REFERENCE_DATE.getDate() - 7);
+  const weekKey = weekAgo.toISOString().slice(0, 10);
 
+  const thisMonth = REFERENCE_DATE.toISOString().slice(0, 7);
+  const lastMonthDate = new Date(REFERENCE_DATE);
+  lastMonthDate.setMonth(REFERENCE_DATE.getMonth() - 1);
+  const lastMonth = lastMonthDate.toISOString().slice(0, 7);
+
+  const thirtyAgo = new Date(REFERENCE_DATE);
+  thirtyAgo.setDate(REFERENCE_DATE.getDate() - 30);
+  const thirtyKey = thirtyAgo.toISOString().slice(0, 10);
+
+  // 今週のトップフェイス（直近7日）
+  const weekActs = allActivities.filter((a) => {
+    const d = a.createdAt.slice(0, 10);
+    return d >= weekKey && d <= refKey;
+  });
+  const weekFaceCounts = new Map<string, number>();
+  for (const act of weekActs) {
+    weekFaceCounts.set(act.faceId, (weekFaceCounts.get(act.faceId) ?? 0) + 1);
+  }
+  const topFaces = [...weekFaceCounts.entries()]
+    .sort((a, b) => b[1] - a[1])
+    .slice(0, 3)
+    .flatMap(([faceId, count]) => {
+      const face = faces.find((f) => f.id === faceId);
+      return face ? [{ face, count }] : [];
+    });
+
+  // 先月比で増加したフェイス
+  const thisMonthCount = new Map<string, number>();
+  const lastMonthCount = new Map<string, number>();
+  for (const act of allActivities) {
+    const m = act.createdAt.slice(0, 7);
+    if (m === thisMonth) thisMonthCount.set(act.faceId, (thisMonthCount.get(act.faceId) ?? 0) + 1);
+    if (m === lastMonth) lastMonthCount.set(act.faceId, (lastMonthCount.get(act.faceId) ?? 0) + 1);
+  }
+  const grownFaces = faces
+    .map((f) => ({ face: f, diff: (thisMonthCount.get(f.id) ?? 0) - (lastMonthCount.get(f.id) ?? 0) }))
+    .filter((x) => x.diff > 0)
+    .sort((a, b) => b.diff - a.diff)
+    .slice(0, 3);
+
+  // 停滞中フェイス（直近30日間に0投稿）
+  const stalledFaces = faces
+    .filter((f) => !allActivities.some((a) => a.faceId === f.id && a.createdAt.slice(0, 10) >= thirtyKey))
+    .slice(0, 3);
+
+  return (
+    <div style={{ display: "flex", flexDirection: "column", gap: 14 }}>
+      <RailCard title="今週のフェイス">
+        {topFaces.length === 0 ? (
+          <p style={{ fontSize: 12, color: "var(--mf-text-muted)", margin: 0 }}>
+            今週はまだ記録がありません
+          </p>
+        ) : (
+          <div style={{ display: "flex", flexDirection: "column", gap: 10 }}>
+            {topFaces.map(({ face, count }) => (
+              <div key={face.id} style={{ display: "flex", alignItems: "center", gap: 10 }}>
+                <FaceBadge face={face} size={28} radius={8} />
+                <span
+                  style={{
+                    flex: 1,
+                    fontSize: 12.5,
+                    color: "var(--mf-ink)",
+                    overflow: "hidden",
+                    textOverflow: "ellipsis",
+                    whiteSpace: "nowrap",
+                  }}
+                >
+                  {getFaceTitle(face)}
+                </span>
+                <span
+                  style={{
+                    fontSize: 11,
+                    fontWeight: 700,
+                    color: "var(--mf-accent)",
+                    background: "rgba(212,146,42,0.1)",
+                    padding: "2px 7px",
+                    borderRadius: 999,
+                    flexShrink: 0,
+                  }}
+                >
+                  {count}件
+                </span>
+              </div>
+            ))}
+          </div>
+        )}
+      </RailCard>
+
+      {(grownFaces.length > 0 || stalledFaces.length > 0) && (
+        <RailCard title="変化の可視化">
+          <div style={{ display: "flex", flexDirection: "column", gap: 8 }}>
+            {grownFaces.map(({ face, diff }) => (
+              <div key={`grown-${face.id}`} style={{ display: "flex", alignItems: "center", gap: 8 }}>
+                <FaceBadge face={face} size={24} radius={7} />
+                <span
+                  style={{
+                    flex: 1,
+                    fontSize: 12,
+                    color: "var(--mf-ink)",
+                    overflow: "hidden",
+                    textOverflow: "ellipsis",
+                    whiteSpace: "nowrap",
+                  }}
+                >
+                  {getFaceTitle(face)}
+                </span>
+                <span style={{ fontSize: 11, color: "var(--mf-accent)", fontWeight: 600, flexShrink: 0 }}>
+                  ↑+{diff}
+                </span>
+              </div>
+            ))}
+            {stalledFaces.map((face) => (
+              <div key={`stalled-${face.id}`} style={{ display: "flex", alignItems: "center", gap: 8 }}>
+                <FaceBadge face={face} size={24} radius={7} />
+                <span
+                  style={{
+                    flex: 1,
+                    fontSize: 12,
+                    color: "var(--mf-text-sub)",
+                    overflow: "hidden",
+                    textOverflow: "ellipsis",
+                    whiteSpace: "nowrap",
+                  }}
+                >
+                  {getFaceTitle(face)}
+                </span>
+                <span style={{ fontSize: 11, color: "var(--mf-text-muted)", fontWeight: 600, flexShrink: 0 }}>
+                  停滞中
+                </span>
+              </div>
+            ))}
+          </div>
+        </RailCard>
+      )}
+    </div>
+  );
+};
+
+// ── CollectionRail ─────────────────────────────────────────────
+const CollectionRail = () => {
+  const subscribedFaceIds = subscriptionRepository.getSubscribedFaceIds();
+  const subscribedFaces: Face[] = subscribedFaceIds.flatMap((id) => {
+    const face = faceRepository.findById(id);
+    return face ? [face] : [];
+  });
+  const recentActivities = activityRepository.listByFaceIds(subscribedFaceIds).slice(0, 3);
+  const faceMap = new Map(subscribedFaces.map((f) => [f.id, f]));
+  const userMap = new Map(userRepository.listAll().map((u) => [u.id, u]));
+
+  if (subscribedFaces.length === 0) {
+    return (
+      <RailCard title="サブスク中">
+        <p style={{ fontSize: 12.5, color: "var(--mf-text-muted)", margin: 0, lineHeight: 1.7 }}>
+          サブスクしているフェイスがありません。
+          <br />
+          <Link href="/search" style={{ color: "var(--mf-accent)", textDecoration: "none", fontWeight: 600 }}>
+            フェイスを探す →
+          </Link>
+        </p>
+      </RailCard>
+    );
+  }
+
+  return (
+    <div style={{ display: "flex", flexDirection: "column", gap: 14 }}>
+      <RailCard title="サブスク中フェイス">
+        <div style={{ display: "flex", flexDirection: "column", gap: 10 }}>
+          {subscribedFaces.map((face) => {
+            const lastAct = activityRepository.listByFaceId(face.id)[0];
+            const owner = userMap.get(face.userId);
+            return (
+              <Link
+                key={face.id}
+                href={`/faces/${face.id}`}
+                style={{ display: "flex", alignItems: "center", gap: 10, textDecoration: "none" }}
+              >
+                <FaceBadge face={face} size={32} radius={9} />
+                <div style={{ flex: 1, minWidth: 0 }}>
+                  <div
+                    style={{
+                      fontSize: 12.5,
+                      fontWeight: 700,
+                      color: "var(--mf-brand)",
+                      overflow: "hidden",
+                      textOverflow: "ellipsis",
+                      whiteSpace: "nowrap",
+                    }}
+                  >
+                    {getFaceTitle(face)}
+                  </div>
+                  {owner && (
+                    <div style={{ fontSize: 11, color: "var(--mf-text-muted)", marginTop: 1 }}>
+                      {owner.name}
+                    </div>
+                  )}
+                </div>
+                {lastAct && (
+                  <span style={{ fontSize: 10.5, color: "var(--mf-text-faint)", flexShrink: 0 }}>
+                    {formatRelativeTime(lastAct.createdAt)}
+                  </span>
+                )}
+              </Link>
+            );
+          })}
+        </div>
+      </RailCard>
+
+      {recentActivities.length > 0 && (
+        <RailCard title="最新シード">
+          <div style={{ marginTop: -6 }}>
+            {recentActivities.map((act) => {
+              const face = faceMap.get(act.faceId);
+              if (!face) return null;
+              return (
+                <SeedRow
+                  key={act.id}
+                  activity={act}
+                  face={face}
+                  noBorder
+                />
+              );
+            })}
+            <Link
+              href="/subscriptions"
+              style={{
+                display: "block",
+                textAlign: "center",
+                fontSize: 12,
+                color: "var(--mf-text-muted)",
+                marginTop: 6,
+                textDecoration: "none",
+                padding: "6px 0",
+              }}
+            >
+              もっと見る →
+            </Link>
+          </div>
+        </RailCard>
+      )}
+    </div>
+  );
+};
+
+// ── ContextRail（メイン） ───────────────────────────────────────
 const ContextRail = () => {
   const pathname = usePathname();
   const { state } = useDetailPanel();
 
-  const hasDetail =
-    state.type === "activity" || state.type === "face";
+  const hasDetail = state.type === "activity" || state.type === "face";
 
   const contentKey = hasDetail
     ? state.type === "activity"

--- a/src/components/ui/ContextRail.tsx
+++ b/src/components/ui/ContextRail.tsx
@@ -1,0 +1,166 @@
+"use client";
+
+import { usePathname } from "next/navigation";
+import { useDetailPanel } from "@/lib/detail-panel-context";
+import ActivityDetail from "./ActivityDetail";
+import FaceDetail from "./FaceDetail";
+import RailCard from "./RailCard";
+
+const WritingRail = () => (
+  <div style={{ display: "flex", flexDirection: "column", gap: 14 }}>
+    <RailCard title="On This Day">
+      <p
+        style={{
+          fontSize: 13,
+          lineHeight: 1.7,
+          color: "var(--mf-ink)",
+          margin: 0,
+        }}
+      >
+        過去のシードは、今のあなたに何を語りかけますか。
+      </p>
+    </RailCard>
+    <RailCard title="今月の記録">
+      <div style={{ display: "flex", gap: 18 }}>
+        {[
+          { n: "—", l: "シード" },
+          { n: "—", l: "日連続" },
+          { n: "—", l: "フェイス" },
+        ].map((s) => (
+          <div key={s.l} style={{ textAlign: "center" }}>
+            <div
+              style={{
+                fontSize: 22,
+                fontWeight: 700,
+                color: "var(--mf-brand)",
+                fontFamily: "var(--mf-font-serif-en)",
+              }}
+            >
+              {s.n}
+            </div>
+            <div
+              style={{
+                fontSize: 11,
+                color: "var(--mf-text-muted)",
+                marginTop: 2,
+              }}
+            >
+              {s.l}
+            </div>
+          </div>
+        ))}
+      </div>
+    </RailCard>
+    <RailCard pad="14px">
+      <div
+        style={{
+          display: "flex",
+          alignItems: "center",
+          gap: 10,
+          color: "var(--mf-text-muted)",
+          fontSize: 13,
+        }}
+      >
+        <svg width={18} height={18} viewBox="0 0 18 18" fill="none" stroke="currentColor" strokeWidth={1.6} strokeLinecap="round" strokeLinejoin="round">
+          <circle cx={8} cy={8} r={5.5} />
+          <path d="M12.2 12.2L16 16" />
+        </svg>
+        すべてを検索
+        <div
+          style={{
+            marginLeft: "auto",
+            fontSize: 10.5,
+            padding: "2px 6px",
+            background: "var(--mf-surface-tint)",
+            borderRadius: 4,
+            color: "var(--mf-text-sub)",
+            fontWeight: 700,
+          }}
+        >
+          ⌘K
+        </div>
+      </div>
+    </RailCard>
+  </div>
+);
+
+const ReflectionRail = () => (
+  <div style={{ display: "flex", flexDirection: "column", gap: 14 }}>
+    <RailCard title="フェイスについて">
+      <p
+        style={{
+          fontSize: 12.5,
+          lineHeight: 1.75,
+          color: "var(--mf-text-sub)",
+          margin: 0,
+        }}
+      >
+        フェイスは「あなたの多面性」のひとつ。投稿したい内容にあったフェイスで書き、後から自分のために振り返ることができます。
+      </p>
+    </RailCard>
+  </div>
+);
+
+const CollectionRail = () => (
+  <div style={{ display: "flex", flexDirection: "column", gap: 14 }}>
+    <RailCard title="サブスク中">
+      <p
+        style={{
+          fontSize: 12.5,
+          lineHeight: 1.75,
+          color: "var(--mf-text-sub)",
+          margin: 0,
+        }}
+      >
+        サブスクライブしているフェイスの新着シードがここに表示されます。
+      </p>
+    </RailCard>
+  </div>
+);
+
+const ContextRail = () => {
+  const pathname = usePathname();
+  const { state } = useDetailPanel();
+
+  const hasDetail =
+    state.type === "activity" || state.type === "face";
+
+  const contentKey = hasDetail
+    ? state.type === "activity"
+      ? `activity-${state.activityId}`
+      : `face-${state.faceId}`
+    : `page-${pathname}`;
+
+  const renderContent = () => {
+    if (state.type === "activity") {
+      return <ActivityDetail activityId={state.activityId} />;
+    }
+    if (state.type === "face") {
+      return <FaceDetail faceId={state.faceId} />;
+    }
+
+    if (pathname === "/faces" || pathname.startsWith("/faces/")) {
+      return <ReflectionRail />;
+    }
+    if (pathname === "/subscriptions") {
+      return <CollectionRail />;
+    }
+    return <WritingRail />;
+  };
+
+  return (
+    <aside
+      className="hidden lg:flex flex-col shrink-0 overflow-y-auto mf-scroll"
+      style={{
+        width: 340,
+        padding: hasDetail ? 0 : "24px 20px 24px 0",
+      }}
+    >
+      <div key={contentKey} style={{ flex: 1 }}>
+        {renderContent()}
+      </div>
+    </aside>
+  );
+};
+
+export default ContextRail;

--- a/src/components/ui/DateBar.tsx
+++ b/src/components/ui/DateBar.tsx
@@ -1,0 +1,49 @@
+type DateBarProps = {
+  label: string;
+  date: string;
+};
+
+const DateBar = ({ label, date }: DateBarProps) => {
+  return (
+    <div
+      style={{
+        display: "flex",
+        alignItems: "center",
+        gap: 10,
+        padding: "14px 18px 4px",
+      }}
+    >
+      <span
+        style={{
+          fontFamily: "var(--mf-font-sans)",
+          fontSize: 11.5,
+          color: "var(--mf-brand)",
+          letterSpacing: 0.5,
+          fontWeight: 700,
+          whiteSpace: "nowrap",
+        }}
+      >
+        {label}
+      </span>
+      <div
+        style={{
+          flex: 1,
+          height: 0.5,
+          background: "var(--mf-line)",
+        }}
+      />
+      <span
+        style={{
+          fontFamily: "var(--mf-font-sans)",
+          fontSize: 10.5,
+          color: "var(--mf-text-muted)",
+          whiteSpace: "nowrap",
+        }}
+      >
+        {date}
+      </span>
+    </div>
+  );
+};
+
+export default DateBar;

--- a/src/components/ui/FAB.tsx
+++ b/src/components/ui/FAB.tsx
@@ -1,34 +1,48 @@
 "use client";
 
 import { useState } from "react";
-import { Pencil } from "lucide-react";
 import PostModal from "@/components/ui/PostModal";
 
 type Props = {
-  /** モーダルを開いた時点で選択済みにするフェイスID（省略可） */
   defaultFaceId?: string;
 };
 
 const FAB = ({ defaultFaceId }: Props) => {
   const [isModalOpen, setIsModalOpen] = useState(false);
 
-  const handleOpen = () => setIsModalOpen(true);
-  const handleClose = () => setIsModalOpen(false);
-
   return (
     <>
       <button
         type="button"
-        onClick={handleOpen}
+        onClick={() => setIsModalOpen(true)}
         aria-label="投稿する"
-        className="md:hidden fixed bottom-24 right-4 z-40 flex h-14 w-14 items-center justify-center rounded-full bg-violet-600 text-white shadow-lg shadow-violet-900/50 transition-all duration-200 hover:bg-violet-500 active:scale-95 active:bg-violet-700"
+        className="md:hidden fixed z-40"
+        style={{
+          bottom: 88,
+          right: 16,
+          width: 56,
+          height: 56,
+          borderRadius: "50%",
+          background: "var(--mf-accent)",
+          color: "#fff",
+          display: "flex",
+          alignItems: "center",
+          justifyContent: "center",
+          border: "none",
+          cursor: "pointer",
+          boxShadow: "0 4px 20px rgba(212,146,42,0.35)",
+          transition: "transform 0.15s, background 0.15s",
+        }}
       >
-        <Pencil size={22} strokeWidth={2.5} />
+        <svg width={22} height={22} viewBox="0 0 20 20" fill="none" stroke="currentColor" strokeWidth={2.2} strokeLinecap="round" strokeLinejoin="round">
+          <path d="M3 17l1-3.5L13 4.5l3.5 3.5L7.5 17H3z" />
+          <path d="M12 5.5l3.5 3.5" />
+        </svg>
       </button>
 
       <PostModal
         isOpen={isModalOpen}
-        onClose={handleClose}
+        onClose={() => setIsModalOpen(false)}
         defaultFaceId={defaultFaceId}
       />
     </>

--- a/src/components/ui/FaceBadge.tsx
+++ b/src/components/ui/FaceBadge.tsx
@@ -1,0 +1,36 @@
+import { getFaceColor, getFaceKanji, getFaceTitle } from "@/lib/display";
+import type { Face } from "@/types/face";
+
+type FaceBadgeProps = {
+  face: Face;
+  size?: number;
+  radius?: number;
+};
+
+const FaceBadge = ({ face, size = 36, radius = 10 }: FaceBadgeProps) => {
+  const color = getFaceColor(face.id);
+  const kanji = getFaceKanji(getFaceTitle(face));
+
+  return (
+    <div
+      style={{
+        width: size,
+        height: size,
+        borderRadius: radius,
+        background: color,
+        color: "#fff",
+        fontFamily: "var(--mf-font-serif)",
+        fontSize: size * 0.48,
+        fontWeight: 500,
+        display: "flex",
+        alignItems: "center",
+        justifyContent: "center",
+        flexShrink: 0,
+      }}
+    >
+      {kanji}
+    </div>
+  );
+};
+
+export default FaceBadge;

--- a/src/components/ui/FaceChip.tsx
+++ b/src/components/ui/FaceChip.tsx
@@ -1,42 +1,49 @@
+import { getFaceColor } from "@/lib/display";
 import { cn } from "@/lib/utils";
 
 type FaceChipProps = {
   title: string;
   faceId: string;
+  size?: "sm" | "md";
   className?: string;
 };
 
-/**
- * フェイス ID の末尾数字をインデックスとしてカラーパレットから色を決定する。
- * 固定の色パレットを使うのでフェイスごとに一貫した色が付く。
- */
-const COLOR_PALETTE = [
-  "bg-violet-900/60 text-violet-300",
-  "bg-sky-900/60 text-sky-300",
-  "bg-emerald-900/60 text-emerald-300",
-  "bg-amber-900/60 text-amber-300",
-  "bg-rose-900/60 text-rose-300",
-  "bg-pink-900/60 text-pink-300",
-  "bg-teal-900/60 text-teal-300",
-  "bg-orange-900/60 text-orange-300",
-];
+const FaceChip = ({
+  title,
+  faceId,
+  size = "sm",
+  className,
+}: FaceChipProps) => {
+  const color = getFaceColor(faceId);
+  const dotSize = size === "sm" ? 5 : 6;
+  const fontSize = size === "sm" ? 11 : 12;
+  const padding = size === "sm" ? "2px 8px 2px 7px" : "3px 10px 3px 9px";
 
-const getColorClass = (faceId: string): string => {
-  // id 末尾の数字全部を合算して index を決める
-  const digits = faceId.replace(/\D/g, "");
-  const sum = digits.split("").reduce((acc, d) => acc + parseInt(d, 10), 0);
-  return COLOR_PALETTE[sum % COLOR_PALETTE.length];
-};
-
-const FaceChip = ({ title, faceId, className }: FaceChipProps) => {
   return (
     <span
-      className={cn(
-        "inline-flex items-center rounded-full px-2.5 py-0.5 text-xs font-medium",
-        getColorClass(faceId),
-        className,
-      )}
+      className={cn("inline-flex items-center whitespace-nowrap", className)}
+      style={{
+        gap: 5,
+        padding,
+        background: `${color}20`,
+        borderRadius: 999,
+        fontFamily: "var(--mf-font-sans)",
+        fontSize,
+        fontWeight: 600,
+        color,
+        letterSpacing: 0.1,
+      }}
     >
+      <span
+        style={{
+          width: dotSize,
+          height: dotSize,
+          borderRadius: "50%",
+          background: color,
+          flexShrink: 0,
+          display: "inline-block",
+        }}
+      />
       {title}
     </span>
   );

--- a/src/components/ui/FaceDetail.tsx
+++ b/src/components/ui/FaceDetail.tsx
@@ -1,13 +1,12 @@
 "use client";
 
-import { X } from "lucide-react";
 import { faceRepository } from "@/repositories/face-repository";
 import { activityRepository } from "@/repositories/activity-repository";
 import { userRepository } from "@/repositories/user-repository";
 import { useDetailPanel } from "@/lib/detail-panel-context";
 import { createLookupMap, getFaceTitle } from "@/lib/display";
-import FaceHeader from "@/components/face/FaceHeader";
-import ActivityCard from "./ActivityCard";
+import FaceBadge from "./FaceBadge";
+import SeedRow from "./SeedRow";
 
 type FaceDetailProps = {
   faceId: string;
@@ -22,72 +21,150 @@ const FaceDetail = ({ faceId }: FaceDetailProps) => {
 
   if (!face) {
     return (
-      <div className="flex flex-col h-full">
-        <div className="sticky top-0 flex items-center justify-between border-b border-zinc-800 bg-zinc-950/80 px-4 py-3 backdrop-blur-sm">
-          <h2 className="text-sm font-semibold text-zinc-400">フェイス詳細</h2>
+      <div style={{ display: "flex", flexDirection: "column", height: "100%" }}>
+        <div
+          style={{
+            display: "flex",
+            alignItems: "center",
+            justifyContent: "space-between",
+            padding: "14px 16px",
+            borderBottom: "0.5px solid var(--mf-line)",
+          }}
+        >
+          <span style={{ fontSize: 13, fontWeight: 700, color: "var(--mf-brand)" }}>
+            フェイス詳細
+          </span>
           <button
             type="button"
             aria-label="閉じる"
             onClick={close}
-            className="flex h-8 w-8 items-center justify-center rounded-full text-zinc-400 hover:bg-zinc-800 hover:text-zinc-100"
+            style={{
+              width: 28, height: 28, display: "flex", alignItems: "center", justifyContent: "center",
+              borderRadius: "50%", border: "none", background: "transparent",
+              color: "var(--mf-text-muted)", cursor: "pointer",
+            }}
           >
-            <X size={16} />
+            <svg width={16} height={16} viewBox="0 0 20 20" fill="none" stroke="currentColor" strokeWidth={1.6} strokeLinecap="round">
+              <path d="M5 5l10 10M15 5L5 15" />
+            </svg>
           </button>
         </div>
-        <div className="flex flex-col items-center justify-center h-full gap-3 px-8 text-center">
-          <p className="text-sm text-zinc-600">フェイスが見つかりませんでした</p>
+        <div style={{ display: "flex", alignItems: "center", justifyContent: "center", flex: 1, padding: "32px 16px" }}>
+          <p style={{ fontSize: 13, color: "var(--mf-text-muted)" }}>フェイスが見つかりませんでした</p>
         </div>
       </div>
     );
   }
 
   const activities = activityRepository.listByFaceId(faceId);
-  const user = userRepository.findById(face.userId);
   const isOwner = face.userId === currentUser.id;
   const faceTitle = getFaceTitle(face) || face.name;
+  void isOwner;
 
   return (
-    <div className="flex flex-col h-full overflow-y-auto">
+    <div style={{ display: "flex", flexDirection: "column", height: "100%", overflowY: "auto" }}>
       {/* ヘッダー */}
-      <div className="sticky top-0 flex items-center justify-between border-b border-zinc-800 bg-zinc-950/80 px-4 py-3 backdrop-blur-sm">
-        <h2 className="text-sm font-semibold text-zinc-400">フェイス詳細</h2>
+      <div
+        style={{
+          display: "flex",
+          alignItems: "center",
+          justifyContent: "space-between",
+          padding: "14px 16px",
+          borderBottom: "0.5px solid var(--mf-line)",
+          background: "rgba(248,246,241,0.85)",
+          backdropFilter: "blur(10px)",
+          position: "sticky",
+          top: 0,
+          zIndex: 1,
+        }}
+      >
+        <span style={{ fontSize: 13, fontWeight: 700, color: "var(--mf-brand)" }}>
+          フェイス詳細
+        </span>
         <button
           type="button"
           aria-label="閉じる"
           onClick={close}
-          className="flex h-8 w-8 items-center justify-center rounded-full text-zinc-400 hover:bg-zinc-800 hover:text-zinc-100"
+          style={{
+            width: 28, height: 28, display: "flex", alignItems: "center", justifyContent: "center",
+            borderRadius: "50%", border: "none", background: "transparent",
+            color: "var(--mf-text-muted)", cursor: "pointer",
+          }}
         >
-          <X size={16} />
+          <svg width={16} height={16} viewBox="0 0 20 20" fill="none" stroke="currentColor" strokeWidth={1.6} strokeLinecap="round">
+            <path d="M5 5l10 10M15 5L5 15" />
+          </svg>
         </button>
       </div>
 
-      {/* FaceHeader（既存コンポーネントを流用） */}
-      <FaceHeader face={face} isOwner={isOwner} />
-
-      {/* 区切り */}
-      <div className="border-b border-zinc-800" />
+      {/* フェイスサマリー */}
+      <div
+        style={{
+          padding: "16px",
+          display: "flex",
+          alignItems: "flex-start",
+          gap: 12,
+          borderBottom: "0.5px solid var(--mf-line)",
+        }}
+      >
+        <FaceBadge face={face} size={48} radius={13} />
+        <div>
+          <div style={{ fontSize: 16, fontWeight: 700, color: "var(--mf-brand)" }}>
+            {faceTitle}
+          </div>
+          {face.description && (
+            <p
+              style={{
+                fontSize: 12.5,
+                lineHeight: 1.7,
+                color: "var(--mf-text-sub)",
+                margin: "4px 0 0",
+              }}
+            >
+              {face.description}
+            </p>
+          )}
+          <div
+            style={{
+              marginTop: 6,
+              fontSize: 11,
+              color: "var(--mf-text-muted)",
+            }}
+          >
+            {activities.length} シード
+          </div>
+        </div>
+      </div>
 
       {/* アクティビティ一覧 */}
-      <div className="px-4 py-4 flex flex-col gap-3">
-        <p className="text-xs font-semibold uppercase tracking-wider text-zinc-500">
-          このフェイスのアクティビティ
+      <div style={{ padding: "0 16px 16px" }}>
+        <p
+          style={{
+            fontSize: 10.5,
+            fontWeight: 700,
+            letterSpacing: 0.6,
+            textTransform: "uppercase",
+            color: "var(--mf-text-muted)",
+            padding: "12px 0 4px",
+          }}
+        >
+          このフェイスのシード
         </p>
         {activities.length === 0 ? (
-          <p className="text-sm text-zinc-600">まだアクティビティがありません</p>
+          <p style={{ fontSize: 13, color: "var(--mf-text-muted)" }}>
+            まだシードがありません
+          </p>
         ) : (
           activities.map((activity, i) => {
-            const activityUser = userMap.get(activity.userId) ?? user;
+            const activityUser = userMap.get(activity.userId);
             if (!activityUser) return null;
-
             return (
-              <ActivityCard
+              <SeedRow
                 key={activity.id}
                 activity={activity}
-                user={activityUser}
-                faceTitle={faceTitle}
-                faceId={faceId}
-                priority={i === 0}
+                face={face}
                 onClick={() => openActivity(activity.id)}
+                noBorder={i === activities.length - 1}
               />
             );
           })

--- a/src/components/ui/FaceNavItem.tsx
+++ b/src/components/ui/FaceNavItem.tsx
@@ -1,45 +1,50 @@
 "use client";
 
-import { cn } from "@/lib/utils";
+import FaceBadge from "@/components/ui/FaceBadge";
 import type { Face } from "@/types/face";
 
 type Props = {
   face: Face;
-  /** DetailPanel に表示中のフェイス ID（アクティブ状態の判定に使用）*/
   activeFaceId?: string;
-  /** クリック時のコールバック（Issue #79/#80 で DetailPanel と連携） */
   onClick?: (face: Face) => void;
 };
 
 const FaceNavItem = ({ face, activeFaceId, onClick }: Props) => {
   const isActive = activeFaceId === face.id;
 
-  const handleClick = () => {
-    onClick?.(face);
-  };
-
   return (
     <li>
       <button
         type="button"
-        onClick={handleClick}
-        className={cn(
-          "flex items-center gap-2.5 w-full rounded-xl px-3 py-2 text-sm font-medium transition-all duration-200",
-          isActive
-            ? "bg-violet-500/20 text-violet-400"
-            : "text-zinc-400 hover:bg-zinc-800 hover:text-zinc-100",
-        )}
+        onClick={() => onClick?.(face)}
+        style={{
+          display: "flex",
+          alignItems: "center",
+          gap: 10,
+          width: "100%",
+          padding: "7px 14px",
+          borderRadius: 8,
+          background: isActive ? "rgba(30,42,74,0.07)" : "transparent",
+          border: "none",
+          cursor: "pointer",
+          textAlign: "left",
+          transition: "background 0.15s",
+        }}
       >
-        {/* 絵文字 or 頭文字フォールバック */}
-        {face.emoji ? (
-          <span className="text-base leading-none">{face.emoji}</span>
-        ) : (
-          <span className="flex h-6 w-6 items-center justify-center rounded-full bg-zinc-700 text-xs font-bold text-zinc-300 shrink-0">
-            {face.name.slice(0, 1)}
-          </span>
-        )}
-
-        <span className="truncate text-sm">{face.name}</span>
+        <FaceBadge face={face} size={26} radius={7} />
+        <span
+          style={{
+            flex: 1,
+            fontSize: 13,
+            fontWeight: 600,
+            color: "var(--mf-text)",
+            overflow: "hidden",
+            textOverflow: "ellipsis",
+            whiteSpace: "nowrap",
+          }}
+        >
+          {face.name}
+        </span>
       </button>
     </li>
   );

--- a/src/components/ui/PostModal.tsx
+++ b/src/components/ui/PostModal.tsx
@@ -1,12 +1,13 @@
 "use client";
 
 import { useEffect, useMemo, useRef, useState } from "react";
-import { X, ChevronDown, ImagePlus } from "lucide-react";
-import { cn } from "@/lib/utils";
 import { faceRepository } from "@/repositories/face-repository";
 import { userRepository } from "@/repositories/user-repository";
+import FaceBadge from "./FaceBadge";
+import { getFaceTitle } from "@/lib/display";
 
 const MAX_IMAGES = 4;
+const MAX_LENGTH = 5000;
 
 type AttachedImage = {
   file: File;
@@ -16,27 +17,26 @@ type AttachedImage = {
 type Props = {
   isOpen: boolean;
   onClose: () => void;
-  /** モーダルを開いた時点で選択済みにするフェイスID（省略可） */
   defaultFaceId?: string;
 };
 
 const PostModal = ({ isOpen, onClose, defaultFaceId }: Props) => {
   const currentUser = userRepository.getCurrentUser();
-  const myFaces = useMemo(() => {
-    return faceRepository.listByUserId(currentUser.id);
-  }, [currentUser.id]);
-  const initialSelectedFaceId = useMemo(() => {
-    return defaultFaceId ?? myFaces[0]?.id ?? "";
-  }, [defaultFaceId, myFaces]);
+  const myFaces = useMemo(
+    () => faceRepository.listByUserId(currentUser.id),
+    [currentUser.id],
+  );
+  const initialSelectedFaceId = useMemo(
+    () => defaultFaceId ?? myFaces[0]?.id ?? "",
+    [defaultFaceId, myFaces],
+  );
   const [selectedFaceId, setSelectedFaceId] = useState<string>(initialSelectedFaceId);
   const [text, setText] = useState("");
   const [images, setImages] = useState<AttachedImage[]>([]);
   const fileInputRef = useRef<HTMLInputElement>(null);
-  const MAX_LENGTH = 5000;
 
   const selectedFace = myFaces.find((f) => f.id === selectedFaceId);
 
-  // モーダルが閉じたら画像をリセット・objectURL を解放
   useEffect(() => {
     if (!isOpen) {
       setImages((prev) => {
@@ -48,7 +48,6 @@ const PostModal = ({ isOpen, onClose, defaultFaceId }: Props) => {
     }
   }, [initialSelectedFaceId, isOpen]);
 
-  // アンマウント時の残存 objectURL クリーンアップ
   useEffect(() => {
     return () => {
       images.forEach((img) => URL.revokeObjectURL(img.objectUrl));
@@ -60,12 +59,10 @@ const PostModal = ({ isOpen, onClose, defaultFaceId }: Props) => {
     const files = Array.from(e.target.files ?? []);
     const remaining = MAX_IMAGES - images.length;
     const toAdd = files.slice(0, remaining);
-    const newImages: AttachedImage[] = toAdd.map((file) => ({
-      file,
-      objectUrl: URL.createObjectURL(file),
-    }));
-    setImages((prev) => [...prev, ...newImages]);
-    // 同じファイルを再選択できるようにリセット
+    setImages((prev) => [
+      ...prev,
+      ...toAdd.map((file) => ({ file, objectUrl: URL.createObjectURL(file) })),
+    ]);
     e.target.value = "";
   };
 
@@ -82,7 +79,13 @@ const PostModal = ({ isOpen, onClose, defaultFaceId }: Props) => {
     <>
       {/* オーバーレイ */}
       <div
-        className="fixed inset-0 z-50 bg-black/60 backdrop-blur-sm"
+        style={{
+          position: "fixed",
+          inset: 0,
+          zIndex: 50,
+          background: "rgba(20,24,36,0.5)",
+          backdropFilter: "blur(4px)",
+        }}
         onClick={onClose}
         aria-hidden="true"
       />
@@ -92,67 +95,93 @@ const PostModal = ({ isOpen, onClose, defaultFaceId }: Props) => {
         role="dialog"
         aria-modal="true"
         aria-label="投稿"
-        className="fixed left-1/2 top-1/2 z-50 w-[calc(100%-2rem)] max-w-sm -translate-x-1/2 -translate-y-1/2 rounded-2xl bg-zinc-900 shadow-xl"
+        style={{
+          position: "fixed",
+          left: "50%",
+          top: "50%",
+          zIndex: 50,
+          width: "calc(100% - 2rem)",
+          maxWidth: 480,
+          transform: "translate(-50%, -50%)",
+          borderRadius: 20,
+          background: "var(--mf-surface)",
+          border: "0.5px solid var(--mf-line)",
+          boxShadow: "0 20px 60px rgba(30,42,74,0.15)",
+        }}
       >
         {/* ヘッダー */}
-        <div className="flex items-center justify-between px-4 pt-4 pb-2">
-          <h2 className="text-base font-bold text-zinc-100">投稿する</h2>
+        <div
+          style={{
+            display: "flex",
+            alignItems: "center",
+            justifyContent: "space-between",
+            padding: "16px 18px 14px",
+            borderBottom: "0.5px solid var(--mf-line)",
+          }}
+        >
+          <h2 style={{ fontSize: 15, fontWeight: 700, color: "var(--mf-brand)", margin: 0 }}>
+            新しいシードを書く
+          </h2>
           <button
             type="button"
             onClick={onClose}
-            className="flex h-8 w-8 items-center justify-center rounded-full text-zinc-400 transition-colors hover:bg-zinc-800 hover:text-zinc-100"
+            style={{
+              width: 28, height: 28,
+              display: "flex", alignItems: "center", justifyContent: "center",
+              borderRadius: "50%", border: "none", background: "transparent",
+              color: "var(--mf-text-muted)", cursor: "pointer",
+            }}
             aria-label="閉じる"
           >
-            <X size={18} />
+            <svg width={16} height={16} viewBox="0 0 20 20" fill="none" stroke="currentColor" strokeWidth={1.6} strokeLinecap="round">
+              <path d="M5 5l10 10M15 5L5 15" />
+            </svg>
           </button>
         </div>
 
-        <div className="px-4 pb-6 flex flex-col gap-4">
+        <div style={{ padding: "16px 18px 20px", display: "flex", flexDirection: "column", gap: 14 }}>
           {/* フェイス選択 */}
-          <div className="flex flex-col gap-1.5">
+          <div>
             <label
               htmlFor="face-select"
-              className="text-xs font-medium text-zinc-400"
+              style={{ fontSize: 11.5, fontWeight: 600, color: "var(--mf-text-muted)", display: "block", marginBottom: 6 }}
             >
               フェイス
             </label>
-            <div className="relative">
+            <div style={{ display: "flex", alignItems: "center", gap: 10, padding: "8px 12px 8px 8px", borderRadius: 12, border: "0.5px solid var(--mf-line)", background: "var(--mf-bg-paper)" }}>
+              {selectedFace && <FaceBadge face={selectedFace} size={28} radius={7} />}
               <select
                 id="face-select"
                 value={selectedFaceId}
                 onChange={(e) => setSelectedFaceId(e.target.value)}
-                className={cn(
-                  "w-full appearance-none rounded-xl border border-zinc-700 bg-zinc-800 px-4 py-2.5 pr-10",
-                  "text-sm text-zinc-100 outline-none transition-colors",
-                  "focus:border-violet-500 focus:ring-1 focus:ring-violet-500/50",
-                )}
+                style={{
+                  flex: 1,
+                  appearance: "none",
+                  border: "none",
+                  background: "transparent",
+                  fontSize: 13.5,
+                  fontWeight: 700,
+                  color: "var(--mf-brand)",
+                  outline: "none",
+                  cursor: "pointer",
+                }}
               >
                 {myFaces.map((face) => (
                   <option key={face.id} value={face.id}>
-                    {face.emoji ? `${face.emoji} ${face.name}` : face.name}
+                    {getFaceTitle(face)}
                   </option>
                 ))}
               </select>
-              <ChevronDown
-                size={16}
-                className="pointer-events-none absolute right-3 top-1/2 -translate-y-1/2 text-zinc-400"
-              />
             </div>
             {selectedFace?.description && (
-              <p className="text-xs text-zinc-500 leading-relaxed">
+              <p style={{ fontSize: 11.5, color: "var(--mf-text-muted)", margin: "6px 0 0", lineHeight: 1.5 }}>
                 {selectedFace.description}
               </p>
             )}
           </div>
 
           {/* テキストエリア */}
-          <div className="flex flex-col gap-1.5">
-            <label
-              htmlFor="post-text"
-              className="text-xs font-medium text-zinc-400"
-            >
-              内容
-            </label>
+          <div>
             <textarea
               id="post-text"
               value={text}
@@ -160,71 +189,92 @@ const PostModal = ({ isOpen, onClose, defaultFaceId }: Props) => {
               maxLength={MAX_LENGTH}
               rows={5}
               placeholder="気軽に書き留めてみましょう…"
-              className={cn(
-                "w-full resize-none rounded-xl border border-zinc-700 bg-zinc-800 px-4 py-3",
-                "text-sm text-zinc-100 placeholder:text-zinc-600 outline-none transition-colors",
-                "focus:border-violet-500 focus:ring-1 focus:ring-violet-500/50",
-              )}
+              style={{
+                width: "100%",
+                resize: "none",
+                borderRadius: 12,
+                border: "0.5px solid var(--mf-line)",
+                background: "var(--mf-bg-paper)",
+                padding: "12px 14px",
+                fontSize: 14,
+                lineHeight: 1.75,
+                color: "var(--mf-ink)",
+                outline: "none",
+                fontFamily: "var(--mf-font-sans)",
+                boxSizing: "border-box",
+              }}
             />
-            <p className="text-right text-xs text-zinc-600">
+            <p style={{ textAlign: "right", fontSize: 11, color: "var(--mf-text-muted)", margin: "4px 0 0" }}>
               {text.length} / {MAX_LENGTH.toLocaleString()}
             </p>
           </div>
 
-          {/* 画像添付エリア */}
-          <div className="flex flex-col gap-2">
-            {/* hidden file input */}
+          {/* 画像添付 */}
+          <div>
             <input
               ref={fileInputRef}
               type="file"
               accept="image/*"
               multiple
-              className="hidden"
+              style={{ display: "none" }}
               onChange={handleFileChange}
             />
-            {/* 添付ボタン */}
             <button
               type="button"
               disabled={images.length >= MAX_IMAGES}
               onClick={() => fileInputRef.current?.click()}
-              className={cn(
-                "flex items-center gap-2 rounded-xl border px-4 py-2 text-sm font-medium transition-all duration-200 w-fit",
-                images.length >= MAX_IMAGES
-                  ? "cursor-not-allowed border-zinc-800 text-zinc-600"
-                  : "border-zinc-700 text-zinc-400 hover:border-violet-500 hover:text-violet-400 hover:bg-violet-500/10 active:scale-95",
-              )}
+              style={{
+                display: "flex",
+                alignItems: "center",
+                gap: 6,
+                padding: "7px 14px",
+                borderRadius: 999,
+                border: "0.5px solid var(--mf-line)",
+                background: "transparent",
+                fontSize: 12.5,
+                fontWeight: 600,
+                color: images.length >= MAX_IMAGES ? "var(--mf-text-faint)" : "var(--mf-text-sub)",
+                cursor: images.length >= MAX_IMAGES ? "not-allowed" : "pointer",
+              }}
             >
-              <ImagePlus size={15} />
+              <svg width={15} height={15} viewBox="0 0 20 20" fill="none" stroke="currentColor" strokeWidth={1.6} strokeLinecap="round" strokeLinejoin="round">
+                <rect x={3} y={3} width={14} height={14} rx={2} />
+                <circle cx={7} cy={7.5} r={1.2} />
+                <path d="M3 14l4-4 4 4 3-3 3 3" />
+              </svg>
               写真を追加
               {images.length > 0 && (
-                <span className={cn(
-                  "ml-0.5 rounded-full px-1.5 py-0.5 text-xs font-bold leading-none",
-                  images.length >= MAX_IMAGES
-                    ? "bg-zinc-800 text-zinc-600"
-                    : "bg-violet-500/20 text-violet-400",
-                )}>
+                <span style={{ fontSize: 11, fontWeight: 700, color: "var(--mf-accent)" }}>
                   {images.length}/{MAX_IMAGES}
                 </span>
               )}
             </button>
-            {/* サムネイルプレビュー */}
+
             {images.length > 0 && (
-              <div className="grid grid-cols-2 gap-2">
+              <div style={{ display: "grid", gridTemplateColumns: "repeat(2, 1fr)", gap: 6, marginTop: 8 }}>
                 {images.map((img, index) => (
-                  <div key={img.objectUrl} className="relative aspect-square">
+                  <div key={img.objectUrl} style={{ position: "relative", aspectRatio: "1/1" }}>
                     {/* eslint-disable-next-line @next/next/no-img-element */}
                     <img
                       src={img.objectUrl}
                       alt={`添付画像${index + 1}`}
-                      className="h-full w-full rounded-lg object-cover"
+                      style={{ width: "100%", height: "100%", borderRadius: 10, objectFit: "cover" }}
                     />
                     <button
                       type="button"
                       onClick={() => handleRemoveImage(index)}
-                      className="absolute right-1 top-1 flex h-5 w-5 items-center justify-center rounded-full bg-black/70 text-white transition-colors hover:bg-black"
+                      style={{
+                        position: "absolute", top: 4, right: 4,
+                        width: 20, height: 20,
+                        display: "flex", alignItems: "center", justifyContent: "center",
+                        borderRadius: "50%", background: "rgba(20,24,36,0.70)",
+                        color: "#fff", border: "none", cursor: "pointer",
+                      }}
                       aria-label={`画像${index + 1}を削除`}
                     >
-                      <X size={12} />
+                      <svg width={10} height={10} viewBox="0 0 20 20" fill="none" stroke="currentColor" strokeWidth={2} strokeLinecap="round">
+                        <path d="M5 5l10 10M15 5L5 15" />
+                      </svg>
                     </button>
                   </div>
                 ))}
@@ -232,16 +282,23 @@ const PostModal = ({ isOpen, onClose, defaultFaceId }: Props) => {
             )}
           </div>
 
-          {/* 投稿ボタン（モック：押しても何もしない） */}
+          {/* 投稿ボタン */}
           <button
             type="button"
             disabled={text.trim().length === 0}
-            className={cn(
-              "w-full rounded-xl py-3 text-sm font-bold transition-colors",
-              text.trim().length > 0
-                ? "bg-violet-600 text-white hover:bg-violet-500 active:bg-violet-700"
-                : "bg-zinc-800 text-zinc-600 cursor-not-allowed",
-            )}
+            style={{
+              width: "100%",
+              padding: "12px",
+              borderRadius: 999,
+              background: text.trim().length > 0 ? "var(--mf-accent)" : "var(--mf-surface-tint)",
+              color: text.trim().length > 0 ? "#fff" : "var(--mf-text-faint)",
+              fontSize: 14,
+              fontWeight: 700,
+              border: "none",
+              cursor: text.trim().length > 0 ? "pointer" : "not-allowed",
+              boxShadow: text.trim().length > 0 ? "0 4px 14px rgba(212,146,42,0.25)" : "none",
+              transition: "background 0.15s, box-shadow 0.15s",
+            }}
           >
             投稿する
           </button>

--- a/src/components/ui/RailCard.tsx
+++ b/src/components/ui/RailCard.tsx
@@ -1,0 +1,60 @@
+import type { ReactNode } from "react";
+
+type RailCardProps = {
+  title?: string;
+  action?: ReactNode;
+  pad?: string;
+  children: ReactNode;
+};
+
+const RailCard = ({ title, action, pad = "16px", children }: RailCardProps) => {
+  return (
+    <div
+      style={{
+        background: "var(--mf-surface)",
+        border: "0.5px solid var(--mf-line)",
+        borderRadius: 14,
+        overflow: "hidden",
+      }}
+    >
+      {title && (
+        <div
+          style={{
+            padding: "14px 16px 10px",
+            display: "flex",
+            alignItems: "baseline",
+            justifyContent: "space-between",
+            gap: 8,
+          }}
+        >
+          <div
+            style={{
+              fontSize: 13,
+              fontWeight: 700,
+              color: "var(--mf-brand)",
+              letterSpacing: 0.2,
+              whiteSpace: "nowrap",
+            }}
+          >
+            {title}
+          </div>
+          {action && (
+            <div
+              style={{
+                fontSize: 11,
+                color: "var(--mf-text-muted)",
+                fontWeight: 600,
+                whiteSpace: "nowrap",
+              }}
+            >
+              {action}
+            </div>
+          )}
+        </div>
+      )}
+      <div style={{ padding: title ? `0 ${pad} ${pad}` : pad }}>{children}</div>
+    </div>
+  );
+};
+
+export default RailCard;

--- a/src/components/ui/SeedRow.tsx
+++ b/src/components/ui/SeedRow.tsx
@@ -188,8 +188,63 @@ const SeedRow = ({
           </div>
         )}
 
-        {/* リンク数 */}
-        {linkedCount > 0 && !showActions && (
+        {/* アクション行 or リンク数表示 */}
+        {showActions ? (
+          <div
+            style={{
+              marginTop: 10,
+              display: "flex",
+              alignItems: "center",
+              gap: 16,
+            }}
+          >
+            {linkedCount > 0 && (
+              <button
+                type="button"
+                onClick={(e) => e.stopPropagation()}
+                style={{
+                  display: "flex",
+                  alignItems: "center",
+                  gap: 5,
+                  fontSize: 12,
+                  color: "var(--mf-text-muted)",
+                  background: "none",
+                  border: "none",
+                  padding: 0,
+                  cursor: "pointer",
+                  fontFamily: "var(--mf-font-sans)",
+                }}
+              >
+                <svg width={14} height={14} viewBox="0 0 16 16" fill="none" stroke="currentColor" strokeWidth={1.5} strokeLinecap="round" strokeLinejoin="round">
+                  <path d="M6.5 9.5a3.54 3.54 0 005 0l2-2a3.54 3.54 0 00-5-5l-1 1" />
+                  <path d="M9.5 6.5a3.54 3.54 0 00-5 0l-2 2a3.54 3.54 0 005 5l1-1" />
+                </svg>
+                <span>{linkedCount}</span>
+              </button>
+            )}
+            <button
+              type="button"
+              onClick={(e) => e.stopPropagation()}
+              style={{
+                display: "flex",
+                alignItems: "center",
+                gap: 5,
+                fontSize: 12,
+                color: "var(--mf-text-muted)",
+                background: "none",
+                border: "none",
+                padding: 0,
+                cursor: "pointer",
+                fontFamily: "var(--mf-font-sans)",
+              }}
+            >
+              <svg width={14} height={14} viewBox="0 0 16 16" fill="none" stroke="currentColor" strokeWidth={1.5} strokeLinecap="round" strokeLinejoin="round">
+                <path d="M11 2a1.414 1.414 0 012 2L5 12l-3 1 1-3L11 2z" />
+              </svg>
+              <span>編集</span>
+            </button>
+          </div>
+        ) : linkedCount > 0 ? (
           <div
             style={{
               marginTop: 10,
@@ -206,19 +261,16 @@ const SeedRow = ({
               whiteSpace: "nowrap",
             }}
           >
+            <svg width={12} height={12} viewBox="0 0 16 16" fill="none" stroke="currentColor" strokeWidth={1.5} strokeLinecap="round" strokeLinejoin="round" style={{ flexShrink: 0 }}>
+              <path d="M6.5 9.5a3.54 3.54 0 005 0l2-2a3.54 3.54 0 00-5-5l-1 1" />
+              <path d="M9.5 6.5a3.54 3.54 0 00-5 0l-2 2a3.54 3.54 0 005 5l1-1" />
+            </svg>
             <span>
-              <b
-                style={{
-                  color: "var(--mf-text)",
-                  fontWeight: 600,
-                }}
-              >
-                {linkedCount}
-              </b>{" "}
+              <b style={{ color: "var(--mf-text)", fontWeight: 600 }}>{linkedCount}</b>{" "}
               件のリンク
             </span>
           </div>
-        )}
+        ) : null}
       </div>
     </div>
   );

--- a/src/components/ui/SeedRow.tsx
+++ b/src/components/ui/SeedRow.tsx
@@ -1,0 +1,227 @@
+"use client";
+
+import { useState } from "react";
+import Image from "next/image";
+import type { Activity } from "@/types/activity";
+import type { Face } from "@/types/face";
+import FaceBadge from "./FaceBadge";
+import { getFaceTitle } from "@/lib/display";
+import { formatRelativeTime } from "@/lib/format-relative-time";
+
+type SeedRowProps = {
+  activity: Activity;
+  face: Face;
+  onClick?: () => void;
+  replyChain?: boolean;
+  showActions?: boolean;
+  noBorder?: boolean;
+};
+
+const COLLAPSE_THRESHOLD = 200;
+
+const SeedRow = ({
+  activity,
+  face,
+  onClick,
+  replyChain = false,
+  showActions = false,
+  noBorder = false,
+}: SeedRowProps) => {
+  const [expanded, setExpanded] = useState(false);
+  const isLong = activity.body.length > COLLAPSE_THRESHOLD;
+  const displayBody =
+    isLong && !expanded
+      ? activity.body.slice(0, COLLAPSE_THRESHOLD) + "…"
+      : activity.body;
+
+  const linkedCount = activity.linkedActivityIds?.length ?? 0;
+
+  return (
+    <div
+      onClick={onClick}
+      role={onClick ? "button" : undefined}
+      tabIndex={onClick ? 0 : undefined}
+      onKeyDown={
+        onClick
+          ? (e) => {
+              if (e.key === "Enter" || e.key === " ") {
+                e.preventDefault();
+                onClick();
+              }
+            }
+          : undefined
+      }
+      style={{
+        padding: "14px 0",
+        borderBottom: noBorder
+          ? "none"
+          : "0.5px solid var(--mf-line-soft)",
+        display: "flex",
+        gap: 12,
+        cursor: onClick ? "pointer" : undefined,
+      }}
+    >
+      {/* 左: FaceBadge + リプライチェーン線 */}
+      <div
+        style={{
+          display: "flex",
+          flexDirection: "column",
+          alignItems: "center",
+          flexShrink: 0,
+        }}
+      >
+        <FaceBadge face={face} size={36} radius={10} />
+        {replyChain && (
+          <div
+            style={{
+              width: 2,
+              flex: 1,
+              background: "var(--mf-line-soft)",
+              marginTop: 6,
+            }}
+          />
+        )}
+      </div>
+
+      {/* 右: メタ情報 + 本文 */}
+      <div style={{ flex: 1, minWidth: 0 }}>
+        {/* ヘッダー行 */}
+        <div
+          style={{
+            display: "flex",
+            alignItems: "center",
+            gap: 6,
+            marginBottom: 4,
+            whiteSpace: "nowrap",
+            overflow: "hidden",
+          }}
+        >
+          <span
+            style={{
+              fontFamily: "var(--mf-font-sans)",
+              fontSize: 13.5,
+              fontWeight: 700,
+              color: "var(--mf-brand)",
+              overflow: "hidden",
+              textOverflow: "ellipsis",
+            }}
+          >
+            {getFaceTitle(face)}
+          </span>
+          <span style={{ fontSize: 12.5, color: "var(--mf-text-muted)" }}>
+            ·
+          </span>
+          <span style={{ fontSize: 12.5, color: "var(--mf-text-muted)" }}>
+            {formatRelativeTime(activity.createdAt)}
+          </span>
+        </div>
+
+        {/* 本文 */}
+        <div
+          style={{
+            fontFamily: "var(--mf-font-sans)",
+            fontSize: 14,
+            lineHeight: 1.65,
+            color: "var(--mf-ink)",
+            whiteSpace: "pre-wrap",
+          }}
+        >
+          {displayBody}
+        </div>
+
+        {/* もっと見る */}
+        {isLong && (
+          <button
+            type="button"
+            onClick={(e) => {
+              e.stopPropagation();
+              setExpanded((prev) => !prev);
+            }}
+            style={{
+              marginTop: 4,
+              fontSize: 12.5,
+              color: "var(--mf-accent)",
+              fontFamily: "var(--mf-font-sans)",
+              fontWeight: 600,
+              background: "none",
+              border: "none",
+              padding: 0,
+              cursor: "pointer",
+            }}
+          >
+            {expanded ? "折りたたむ" : "続きを読む"}
+          </button>
+        )}
+
+        {/* 画像 */}
+        {activity.imageUrls && activity.imageUrls.length > 0 && (
+          <div
+            style={{
+              marginTop: 10,
+              display: "grid",
+              gridTemplateColumns: `repeat(${Math.min(activity.imageUrls.length, 2)}, 1fr)`,
+              gap: 3,
+              borderRadius: 14,
+              overflow: "hidden",
+              border: "0.5px solid var(--mf-line-soft)",
+            }}
+          >
+            {activity.imageUrls.slice(0, 4).map((url, i) => (
+              <div
+                key={i}
+                style={{
+                  position: "relative",
+                  aspectRatio:
+                    activity.imageUrls!.length === 1 ? "16/10" : "1/1",
+                }}
+              >
+                <Image
+                  src={url}
+                  alt={`画像 ${i + 1}`}
+                  fill
+                  className="object-cover"
+                  sizes="(max-width: 384px) 100vw, 192px"
+                  loading={i === 0 ? "eager" : "lazy"}
+                />
+              </div>
+            ))}
+          </div>
+        )}
+
+        {/* リンク数 */}
+        {linkedCount > 0 && !showActions && (
+          <div
+            style={{
+              marginTop: 10,
+              padding: "8px 10px",
+              background: "var(--mf-surface-card)",
+              border: "1px solid var(--mf-line-soft)",
+              borderRadius: 10,
+              display: "inline-flex",
+              alignItems: "center",
+              gap: 6,
+              fontSize: 12,
+              color: "var(--mf-text-sub)",
+              fontFamily: "var(--mf-font-sans)",
+              whiteSpace: "nowrap",
+            }}
+          >
+            <span>
+              <b
+                style={{
+                  color: "var(--mf-text)",
+                  fontWeight: 600,
+                }}
+              >
+                {linkedCount}
+              </b>{" "}
+              件のリンク
+            </span>
+          </div>
+        )}
+      </div>
+    </div>
+  );
+};
+
+export default SeedRow;

--- a/src/components/ui/SideNav.tsx
+++ b/src/components/ui/SideNav.tsx
@@ -3,8 +3,8 @@
 import { useState } from "react";
 import Link from "next/link";
 import { usePathname, useRouter } from "next/navigation";
-import { Home, Bell, Search, Rss, Plus, type LucideIcon } from "lucide-react";
-import { cn } from "@/lib/utils";
+import Wordmark from "@/components/ui/Wordmark";
+import FaceBadge from "@/components/ui/FaceBadge";
 import FaceNavItem from "@/components/ui/FaceNavItem";
 import CreateFaceModal from "@/components/face/CreateFaceModal";
 import { faceRepository } from "@/repositories/face-repository";
@@ -15,14 +15,51 @@ import type { Face } from "@/types/face";
 type NavItem = {
   href: string;
   label: string;
-  icon: LucideIcon;
+  jp: string;
+  icon: (active: boolean) => React.ReactNode;
+  count?: number;
 };
 
+const PencilIcon = ({ active }: { active: boolean }) => (
+  <svg width={22} height={22} viewBox="0 0 20 20" fill="none" stroke="currentColor" strokeWidth={1.6} strokeLinecap="round" strokeLinejoin="round">
+    {active ? (
+      <path d="M3 17l1-3.5L13 4.5l3.5 3.5L7.5 17H3z" fill="currentColor" />
+    ) : (
+      <>
+        <path d="M3 17l1-3.5L13 4.5l3.5 3.5L7.5 17H3z" />
+        <path d="M12 5.5l3.5 3.5" />
+      </>
+    )}
+  </svg>
+);
+
+const LayersIcon = ({ active }: { active: boolean }) => (
+  <svg width={22} height={22} viewBox="0 0 22 22" fill="none" stroke="currentColor" strokeWidth={1.6} strokeLinecap="round" strokeLinejoin="round">
+    <path d="M11 3L3 7l8 4 8-4-8-4z" fill={active ? "currentColor" : "none"} />
+    <path d="M3 11l8 4 8-4" opacity={active ? 0.6 : 1} />
+    {!active && <path d="M3 15l8 4 8-4" />}
+  </svg>
+);
+
+const CompassIcon = ({ active }: { active: boolean }) => (
+  <svg width={22} height={22} viewBox="0 0 22 22" fill="none">
+    <circle cx={11} cy={11} r={8} fill={active ? "currentColor" : "none"} fillOpacity={active ? 0.18 : 0} stroke="currentColor" strokeWidth={1.6} />
+    <path d="M14.5 7.5L12.5 12.5 7.5 14.5 9.5 9.5z" fill="currentColor" />
+  </svg>
+);
+
+const BellIcon = ({ active }: { active: boolean }) => (
+  <svg width={22} height={22} viewBox="0 0 20 20" fill="none" stroke="currentColor" strokeWidth={active ? 2 : 1.6} strokeLinecap="round" strokeLinejoin="round">
+    <path d="M4.5 14.5h11l-1.3-1.7c-.5-.7-.8-1.5-.8-2.3V7.8a3.4 3.4 0 00-6.8 0v2.7c0 .8-.3 1.6-.8 2.3l-1.3 1.7z" />
+    <path d="M8.5 16.5a1.5 1.5 0 003 0" />
+  </svg>
+);
+
 const NAV_ITEMS: NavItem[] = [
-  { href: "/", label: "ホーム", icon: Home },
-  { href: "/subscriptions", label: "サブスク", icon: Rss },
-  { href: "/notifications", label: "通知", icon: Bell },
-  { href: "/search", label: "検索", icon: Search },
+  { href: "/",             label: "Writing",     jp: "書く",    icon: (a) => <PencilIcon active={a} /> },
+  { href: "/faces",        label: "Reflection",  jp: "振り返り", icon: (a) => <LayersIcon active={a} /> },
+  { href: "/subscriptions",label: "Collection",  jp: "蒐集",    icon: (a) => <CompassIcon active={a} /> },
+  { href: "/notifications",label: "Notifications",jp: "通知",   icon: (a) => <BellIcon active={a} />, count: 0 },
 ];
 
 const SideNav = () => {
@@ -34,17 +71,9 @@ const SideNav = () => {
   const faces = faceRepository.listByUserId(currentUser.id);
   const { openFace } = useDetailPanel();
 
-  // パス名からアクティブなフェイスIDを導出
   const activeFaceId = pathname.startsWith("/faces/")
     ? pathname.split("/")[2]
     : undefined;
-
-  const handleOpenCreateModal = () => setIsCreateModalOpen(true);
-  const handleCloseCreateModal = () => setIsCreateModalOpen(false);
-  const handleCreateFace = (_face: Face) => {
-    // モック実装: 作成後はモーダルを閉じるだけ（実際の永続化は行わない）
-    setIsCreateModalOpen(false);
-  };
 
   const handleFaceNavItemClick = (face: Face) => {
     router.push(`/faces/${face.id}`);
@@ -53,84 +82,226 @@ const SideNav = () => {
 
   return (
     <>
-      <nav className="hidden md:flex flex-col w-60 shrink-0 sticky top-0 h-screen overflow-y-auto pt-6 pb-6 px-3 border-r border-zinc-800">
-        {/* ロゴ・アプリ名 */}
-        <div className="px-3 pb-4">
-          <span className="text-xl font-bold text-violet-400 tracking-tight">
-            MultiFace
-          </span>
+      <nav
+        className="hidden md:flex flex-col shrink-0 sticky top-0 h-screen overflow-y-auto mf-scroll"
+        style={{
+          width: 260,
+          padding: "24px 14px",
+          borderRight: "0.5px solid var(--mf-line)",
+        }}
+      >
+        {/* Wordmark */}
+        <div style={{ padding: "0 12px 28px" }}>
+          <Wordmark size={26} />
         </div>
 
-        {/* ナビゲーションアイテム */}
-        <ul className="flex flex-col gap-1">
+        {/* メインナビゲーション */}
+        <div style={{ display: "flex", flexDirection: "column", gap: 2 }}>
           {NAV_ITEMS.map((item) => {
             const isActive =
               item.href === "/"
                 ? pathname === "/"
-                : pathname === item.href ||
-                  pathname.startsWith(item.href + "/");
-            const Icon = item.icon;
+                : pathname === item.href || pathname.startsWith(item.href + "/");
+
             return (
-              <li key={item.href}>
-                <Link
-                  href={item.href}
-                  className={cn(
-                    "flex items-center gap-3 rounded-xl px-3 py-2.5 text-sm font-medium transition-all duration-200",
-                    isActive
-                      ? "bg-violet-500/20 text-violet-400"
-                      : "text-zinc-400 hover:bg-zinc-800 hover:text-zinc-100",
-                  )}
+              <Link
+                key={item.href}
+                href={item.href}
+                style={{
+                  display: "flex",
+                  alignItems: "center",
+                  gap: 14,
+                  padding: "11px 14px",
+                  borderRadius: 11,
+                  background: isActive ? "rgba(30,42,74,0.10)" : "transparent",
+                  textDecoration: "none",
+                  transition: "background 0.15s",
+                }}
+              >
+                <span
+                  style={{
+                    color: isActive
+                      ? "var(--mf-brand)"
+                      : "var(--mf-text-sub)",
+                    display: "flex",
+                    alignItems: "center",
+                  }}
                 >
-                  <Icon
-                    size={20}
-                    strokeWidth={isActive ? 2.5 : 2}
-                    className={cn(
-                      "shrink-0 transition-all duration-200",
-                      isActive && "[&>*]:fill-current",
-                    )}
-                  />
-                  <span>{item.label}</span>
-                </Link>
-              </li>
+                  {item.icon(isActive)}
+                </span>
+                <div style={{ flex: 1 }}>
+                  <div
+                    style={{
+                      fontSize: 15,
+                      fontWeight: isActive ? 700 : 600,
+                      color: isActive ? "var(--mf-brand)" : "var(--mf-text)",
+                      letterSpacing: 0.1,
+                    }}
+                  >
+                    {item.label}
+                  </div>
+                </div>
+                {item.count && item.count > 0 ? (
+                  <div
+                    style={{
+                      minWidth: 18,
+                      height: 18,
+                      padding: "0 6px",
+                      borderRadius: 999,
+                      background: "var(--mf-accent)",
+                      color: "#fff",
+                      fontSize: 10.5,
+                      fontWeight: 700,
+                      display: "flex",
+                      alignItems: "center",
+                      justifyContent: "center",
+                    }}
+                  >
+                    {item.count}
+                  </div>
+                ) : null}
+              </Link>
             );
           })}
-        </ul>
+        </div>
 
-        {/* 区切り線 */}
-        <hr className="my-3 border-t border-zinc-800" />
+        {/* 投稿ボタン */}
+        <button
+          type="button"
+          onClick={() => {}}
+          style={{
+            marginTop: 18,
+            padding: "13px 16px",
+            borderRadius: 12,
+            background: "var(--mf-accent)",
+            color: "#fff",
+            display: "flex",
+            alignItems: "center",
+            justifyContent: "center",
+            gap: 8,
+            fontSize: 14,
+            fontWeight: 700,
+            letterSpacing: 0.3,
+            boxShadow: "0 4px 14px rgba(212,146,42,0.25)",
+            border: "none",
+            cursor: "pointer",
+          }}
+        >
+          <svg width={16} height={16} viewBox="0 0 20 20" fill="none" stroke="currentColor" strokeWidth={2} strokeLinecap="round" strokeLinejoin="round">
+            <path d="M3 17l1-3.5L13 4.5l3.5 3.5L7.5 17H3z" />
+            <path d="M12 5.5l3.5 3.5" />
+          </svg>
+          新しいシードを書く
+        </button>
 
-        {/* フェイス一覧ラベル */}
-        <p className="px-3 mb-1 text-[12px] font-semibold uppercase tracking-wider text-zinc-600">
-          フェイス
-        </p>
-
-        {/* フェイスリスト */}
-        <ul className="flex flex-col gap-0.5">
-          {faces.map((face) => (
-            <FaceNavItem
-              key={face.id}
-              face={face}
-              activeFaceId={activeFaceId}
-              onClick={handleFaceNavItemClick}
-            />
-          ))}
-        </ul>
+        {/* マイフェイスセクション */}
+        <div style={{ marginTop: 28 }}>
+          <div
+            style={{
+              padding: "0 14px 8px",
+              fontSize: 10.5,
+              color: "var(--mf-text-muted)",
+              fontWeight: 700,
+              letterSpacing: 0.6,
+              textTransform: "uppercase",
+            }}
+          >
+            マイフェイス
+          </div>
+          <ul style={{ listStyle: "none", margin: 0, padding: 0, display: "flex", flexDirection: "column", gap: 0 }}>
+            {faces.map((face) => (
+              <FaceNavItem
+                key={face.id}
+                face={face}
+                activeFaceId={activeFaceId}
+                onClick={handleFaceNavItemClick}
+              />
+            ))}
+          </ul>
+        </div>
 
         {/* 新規フェイス作成ボタン */}
         <button
           type="button"
-          onClick={handleOpenCreateModal}
-          className="flex items-center gap-2 w-full rounded-xl px-3 py-2 mt-2 text-sm font-medium text-zinc-500 hover:bg-zinc-800 hover:text-zinc-300 border border-dashed border-zinc-700"
+          onClick={() => setIsCreateModalOpen(true)}
+          style={{
+            display: "flex",
+            alignItems: "center",
+            gap: 8,
+            width: "100%",
+            padding: "8px 14px",
+            marginTop: 8,
+            borderRadius: 8,
+            background: "transparent",
+            border: "1.5px dashed var(--mf-line)",
+            cursor: "pointer",
+            fontSize: 12.5,
+            fontWeight: 600,
+            color: "var(--mf-text-muted)",
+          }}
         >
-          <Plus size={14} />
+          <svg width={14} height={14} viewBox="0 0 20 20" fill="none" stroke="currentColor" strokeWidth={2} strokeLinecap="round">
+            <path d="M10 4v12M4 10h12" />
+          </svg>
           新規フェイス作成
         </button>
+
+        <div style={{ flex: 1 }} />
+
+        {/* ユーザーピル */}
+        <div
+          style={{
+            display: "flex",
+            alignItems: "center",
+            gap: 10,
+            padding: "10px 12px",
+            borderRadius: 12,
+            background: "var(--mf-surface)",
+            border: "0.5px solid var(--mf-line)",
+          }}
+        >
+          {faces[0] ? (
+            <FaceBadge face={faces[0]} size={36} radius={999} />
+          ) : (
+            <div
+              style={{
+                width: 36,
+                height: 36,
+                borderRadius: "50%",
+                background: "var(--mf-brand)",
+                display: "flex",
+                alignItems: "center",
+                justifyContent: "center",
+                color: "#fff",
+                fontSize: 14,
+                fontWeight: 600,
+                flexShrink: 0,
+              }}
+            >
+              {currentUser.name.slice(0, 1)}
+            </div>
+          )}
+          <div style={{ flex: 1, minWidth: 0 }}>
+            <div
+              style={{
+                fontSize: 13,
+                fontWeight: 700,
+                color: "var(--mf-text)",
+                overflow: "hidden",
+                textOverflow: "ellipsis",
+                whiteSpace: "nowrap",
+              }}
+            >
+              {currentUser.name}
+            </div>
+          </div>
+        </div>
       </nav>
 
       <CreateFaceModal
         isOpen={isCreateModalOpen}
-        onClose={handleCloseCreateModal}
-        onCreate={handleCreateFace}
+        onClose={() => setIsCreateModalOpen(false)}
+        onCreate={() => setIsCreateModalOpen(false)}
       />
     </>
   );

--- a/src/components/ui/TopBar.tsx
+++ b/src/components/ui/TopBar.tsx
@@ -1,51 +1,76 @@
 "use client";
 
 import { useState } from "react";
-import { Pencil } from "lucide-react";
 import { usePathname } from "next/navigation";
 import PostModal from "@/components/ui/PostModal";
 
-type TopBarProps = {
-  pageTitle?: string;
-};
-
 const PAGE_TITLES: Record<string, string> = {
-  "/": "ホーム",
-  "/faces": "フェイス",
+  "/": "書く",
+  "/faces": "振り返り",
+  "/subscriptions": "蒐集",
   "/notifications": "通知",
   "/search": "検索",
-  "/subscriptions": "サブスク",
 };
 
-/**
- * TopBar（グローバル上部バー）
- * PC 表示時に SideNav の右側、MainColumn・DetailPanel の上部に共通表示される。
- */
-const TopBar = ({ pageTitle }: TopBarProps) => {
+const TopBar = () => {
   const pathname = usePathname();
   const [isPostModalOpen, setIsPostModalOpen] = useState(false);
 
   const handleOpen = () => setIsPostModalOpen(true);
   const handleClose = () => setIsPostModalOpen(false);
-  const resolvedPageTitle =
-    pageTitle ??
+
+  const title =
     PAGE_TITLES[pathname] ??
     (pathname.startsWith("/faces/") ? "フェイス詳細" : "MultiFace");
 
   return (
     <>
-      <header className="hidden md:flex items-center justify-between sticky top-0 z-10 h-12 border-b border-zinc-800 bg-zinc-950/80 backdrop-blur-sm px-4">
-        {/* 左側: 現在のページ名 */}
-        <span className="text-sm font-semibold text-zinc-400">{resolvedPageTitle}</span>
+      <header
+        className="hidden md:flex items-center justify-between sticky top-0 z-10"
+        style={{
+          height: 64,
+          padding: "0 28px",
+          borderBottom: "0.5px solid var(--mf-line)",
+          background: "rgba(248,246,241,0.85)",
+          backdropFilter: "blur(10px)",
+        }}
+      >
+        <div>
+          <div
+            style={{
+              fontSize: 19,
+              fontWeight: 700,
+              color: "var(--mf-brand)",
+              letterSpacing: -0.2,
+            }}
+          >
+            {title}
+          </div>
+        </div>
 
-        {/* 右側: 投稿ボタン */}
         <button
           type="button"
           onClick={handleOpen}
-          className="flex items-center gap-2 rounded-full bg-violet-600 px-4 py-1.5 text-sm font-semibold text-white shadow-md shadow-violet-900/40 hover:bg-violet-500 active:scale-95 active:bg-violet-700 transition-all"
+          style={{
+            display: "flex",
+            alignItems: "center",
+            gap: 6,
+            padding: "8px 22px",
+            borderRadius: 999,
+            background: "var(--mf-accent)",
+            color: "#fff",
+            fontSize: 13.5,
+            fontWeight: 700,
+            border: "none",
+            cursor: "pointer",
+            boxShadow: "0 4px 14px rgba(212,146,42,0.25)",
+          }}
         >
-          <Pencil size={16} strokeWidth={2.5} />
-          投稿する
+          <svg width={14} height={14} viewBox="0 0 20 20" fill="none" stroke="currentColor" strokeWidth={2} strokeLinecap="round" strokeLinejoin="round">
+            <path d="M3 17l1-3.5L13 4.5l3.5 3.5L7.5 17H3z" />
+            <path d="M12 5.5l3.5 3.5" />
+          </svg>
+          投稿
         </button>
       </header>
 

--- a/src/components/ui/Wordmark.tsx
+++ b/src/components/ui/Wordmark.tsx
@@ -1,0 +1,42 @@
+type WordmarkProps = {
+  size?: number;
+  color?: string;
+  withDot?: boolean;
+};
+
+const Wordmark = ({ size = 19, color, withDot = true }: WordmarkProps) => {
+  return (
+    <div
+      style={{
+        fontFamily: "var(--mf-font-serif-en)",
+        fontSize: size,
+        fontWeight: 500,
+        letterSpacing: -0.2,
+        color: color ?? "var(--mf-brand)",
+        lineHeight: 1,
+        fontStyle: "italic",
+        display: "inline-flex",
+        alignItems: "baseline",
+        gap: 1,
+        whiteSpace: "nowrap",
+      }}
+    >
+      <span>Multi</span>
+      <span style={{ fontStyle: "normal", fontWeight: 600 }}>Face</span>
+      {withDot && (
+        <span
+          style={{
+            width: size * 0.22,
+            height: size * 0.22,
+            borderRadius: "50%",
+            background: "var(--mf-accent)",
+            marginLeft: 4,
+            alignSelf: "center",
+          }}
+        />
+      )}
+    </div>
+  );
+};
+
+export default Wordmark;

--- a/src/lib/display.ts
+++ b/src/lib/display.ts
@@ -15,3 +15,35 @@ export const getFaceTitle = (
     .join(" ")
     .trim();
 };
+
+/** Midnight Ink の 6 フェイスカラー */
+const MF_FACE_COLORS = [
+  "#5B8DB8", // water  水青
+  "#5B9B72", // moss   苔緑
+  "#7B6B9E", // wisteria 藤紫
+  "#C47A50", // persimmon 柿橙
+  "#B06B7A", // rose   薔薇
+  "#A89050", // grass  枯草
+];
+
+/** faceId の数字和 mod 6 でカラーを決定 */
+export const getFaceColor = (faceId: string): string => {
+  const digits = faceId.replace(/\D/g, "");
+  if (!digits) return MF_FACE_COLORS[0];
+  const sum = digits.split("").reduce((acc, d) => acc + parseInt(d, 10), 0);
+  return MF_FACE_COLORS[sum % MF_FACE_COLORS.length];
+};
+
+/**
+ * faceTitle（例："📚 読書"）から最初の非絵文字・非スペース文字を返す。
+ * サロゲートペア（絵文字）をスキップして最初の通常文字を取得する。
+ */
+export const getFaceKanji = (faceTitle: string): string => {
+  for (const char of faceTitle) {
+    const cp = char.codePointAt(0) ?? 0;
+    if (cp > 0xffff) continue; // サロゲートペア（絵文字）をスキップ
+    if (cp < 0x0021) continue; // 制御文字・スペースをスキップ
+    return char;
+  }
+  return "?";
+};


### PR DESCRIPTION
## Summary

### Midnight Ink デザインシステム基盤 (#99-#108)
- グローバル CSS カスタムプロパティ（`--mf-*` トークン）・Google Fonts 設定
- 新規アトムコンポーネント: `Wordmark`, `FaceBadge`, `SeedRow`, `RailCard`, `DateBar`, `AppHeader`
- ナビゲーション刷新: `BottomNav`（3タブ）/ `SideNav`（NavRail）/ `TopBar` / `ContextRail`
- 全ページのライトテーマ移行（ホーム / フェイス / サブスク / 検索 / 通知）

### 細部実装 (#104-#106 完了分)
- **Writing(/)**: インラインコンポーズボックス + On This Day カード + 最近のシードセクション
- **Reflection(/faces)**: FaceCard カラーバンド + 統計（シード/今月/最終日付）+ FaceHeader ソートピル + 統計行
- **Collection(/subscriptions)**: タブ（タイムライン/サブスク一覧）+ 横スクロールフェイス行 + DateBarグループ + Quiet Feedエンプティステート
- 検索コンポーネント（`SearchBar` / `SearchScopeSelector` / `SearchClient`）MFテーマ対応

### ContextRail実データ化・ソート連携 (#110-#113)
- **#110** `FaceDetailClient.tsx` 新規作成 — FaceHeaderソートピル → FaceActivityFeed への SortOrder 接続
- **#111** `WritingRail` 「今月の記録」を実データに（シード数 / ストリーク日数 / フェイス数）
- **#112** `ReflectionRail` に週次振り返りUI（直近7日トップフェイス + 先月比増加/停滞フェイス）
- **#113** `CollectionRail` にサブスク中フェイス一覧 + 最新シード3件表示

## Test plan

- [ ] モバイル: `BottomNav` 3タブ、`AppHeader` 通知ベル + アバター表示を確認
- [ ] デスクトップ: `SideNav` NavRail・`ContextRail` 右レールが表示されることを確認
- [ ] `/` WritingRail に今月のシード数・ストリーク・フェイス数が表示されることを確認
- [ ] `/faces` FaceCard カラーバンドと統計が表示され、フェイス詳細ページでソートピルが機能することを確認
- [ ] `/faces` ReflectionRail に今週フェイスと変化データが表示されることを確認
- [ ] `/subscriptions` タブ切り替え・DateBarグループ化が機能することを確認
- [ ] `/subscriptions` CollectionRail にサブスクフェイスと最新シードが表示されることを確認
- [ ] `npx next build` でビルドエラーなしを確認

Closes #99, #100, #101, #102, #103, #104, #105, #106, #110, #111, #112, #113

🤖 Generated with [Claude Code](https://claude.com/claude-code)