### PR TITLE
fix(ui): デザインファイル準拠 — FaceCard・ReflectionRail・SideNav・PostModal差分修正

### DIFF
--- a/src/components/face/FacesClient.tsx
+++ b/src/components/face/FacesClient.tsx
@@ -319,9 +319,10 @@ const FacesClient = ({ initialFaces }: Props) => {
                     style={{
                       height: 56,
                       background: color,
+                      padding: 12,
                       display: "flex",
-                      alignItems: "center",
-                      justifyContent: "center",
+                      alignItems: "flex-start",
+                      justifyContent: "space-between",
                       flexShrink: 0,
                     }}
                   >
@@ -335,83 +336,87 @@ const FacesClient = ({ initialFaces }: Props) => {
                         alignItems: "center",
                         justifyContent: "center",
                         fontFamily: "var(--mf-font-serif)",
-                        fontSize: 16,
-                        fontWeight: 600,
+                        fontSize: 14,
+                        fontWeight: 500,
                         color: "#fff",
                       }}
                     >
                       {kanji}
                     </div>
+                    {face.isPrivate ? (
+                      <div style={{
+                        display: "flex", alignItems: "center", gap: 3,
+                        padding: "3px 7px",
+                        background: "rgba(20,24,36,0.32)",
+                        borderRadius: 999,
+                        backdropFilter: "blur(8px)",
+                        WebkitBackdropFilter: "blur(8px)",
+                      }}>
+                        <svg width={10} height={10} viewBox="0 0 14 14" fill="none" stroke="#fff" strokeWidth={1.5} strokeLinecap="round" strokeLinejoin="round">
+                          <rect x={2.5} y={6} width={9} height={6.5} rx={1.2} />
+                          <path d="M4.5 6V4a2.5 2.5 0 015 0v2" />
+                        </svg>
+                        <span style={{ fontSize: 9, color: "#fff", fontWeight: 700, letterSpacing: 0.3 }}>非公開</span>
+                      </div>
+                    ) : (
+                      <svg width={16} height={16} viewBox="0 0 18 18" fill="rgba(255,255,255,0.85)">
+                        <circle cx={3} cy={9} r={1.5} /><circle cx={9} cy={9} r={1.5} /><circle cx={15} cy={9} r={1.5} />
+                      </svg>
+                    )}
                   </div>
 
                   {/* カード本文 */}
-                  <div style={{ padding: "10px 12px 12px", flex: 1, display: "flex", flexDirection: "column" }}>
-                    <div
-                      style={{
-                        fontSize: 14.5,
-                        fontWeight: 700,
-                        color: "var(--mf-brand)",
-                        overflow: "hidden",
-                        textOverflow: "ellipsis",
-                        whiteSpace: "nowrap",
-                        marginBottom: 6,
-                      }}
-                    >
-                      {getFaceTitle(face)}
-                    </div>
+                  <div style={{ padding: "11px 13px 12px", flex: 1, display: "flex", flexDirection: "column", justifyContent: "space-between" }}>
+                    <div>
+                      <div
+                        style={{
+                          fontSize: 14.5,
+                          fontWeight: 700,
+                          color: "var(--mf-brand)",
+                          overflow: "hidden",
+                          textOverflow: "ellipsis",
+                          whiteSpace: "nowrap",
+                          letterSpacing: 0.1,
+                          lineHeight: 1.2,
+                        }}
+                      >
+                        {getFaceTitle(face)}
+                      </div>
 
-                    {/* 統計行 */}
-                    <div
-                      style={{
-                        display: "flex",
-                        alignItems: "baseline",
-                        justifyContent: "space-between",
-                        marginBottom: 4,
-                      }}
-                    >
-                      <span style={{ fontSize: 11, color: "var(--mf-text-sub)" }}>
-                        <b style={{ color: "var(--mf-text)", fontWeight: 700, fontSize: 17 }}>
-                          {stats?.total ?? 0}
-                        </b>{" "}
-                        シード
-                      </span>
-                      {stats && stats.monthly > 0 && (
-                        <span
-                          style={{
-                            fontSize: 10,
-                            color: "var(--mf-accent)",
-                            fontWeight: 600,
-                          }}
-                        >
-                          +{stats.monthly}/月
+                      {/* 統計行 */}
+                      <div
+                        style={{
+                          display: "flex",
+                          alignItems: "baseline",
+                          gap: 6,
+                          marginTop: 5,
+                        }}
+                      >
+                        <span>
+                          <b style={{ color: "var(--mf-text)", fontWeight: 700, fontSize: 17 }}>
+                            {stats?.total ?? 0}
+                          </b>
+                          <span style={{ fontSize: 10, color: "var(--mf-text-muted)", marginLeft: 2 }}>シード</span>
                         </span>
-                      )}
+                        {stats && stats.monthly > 0 && (
+                          <span
+                            style={{
+                              marginLeft: "auto",
+                              fontSize: 10.5,
+                              color,
+                              fontWeight: 700,
+                            }}
+                          >
+                            +{stats.monthly}/月
+                          </span>
+                        )}
+                      </div>
                     </div>
 
                     {/* 最終投稿日 */}
-                    {stats?.lastDate && (
-                      <div style={{ fontSize: 10.5, color: "var(--mf-text-faint)", marginTop: "auto" }}>
-                        {stats.lastDate.replace(/-/g, "/")}
-                      </div>
-                    )}
-
-                    {face.isPrivate && (
-                      <span
-                        style={{
-                          marginTop: 4,
-                          display: "inline-block",
-                          padding: "2px 8px",
-                          borderRadius: 999,
-                          background: "var(--mf-surface-tint)",
-                          fontSize: 10,
-                          color: "var(--mf-text-muted)",
-                          fontWeight: 600,
-                          alignSelf: "flex-start",
-                        }}
-                      >
-                        非公開
-                      </span>
-                    )}
+                    <div style={{ fontSize: 10.5, color: "var(--mf-text-muted)" }}>
+                      {stats?.lastDate ? stats.lastDate.replace(/-/g, "/") : "—"}
+                    </div>
                   </div>
                 </div>
               </Link>

--- a/src/components/home/HomeClient.tsx
+++ b/src/components/home/HomeClient.tsx
@@ -34,14 +34,34 @@ const HomeClient = () => {
 
   const defaultFace = faces[0] ?? null;
 
+  const today = REFERENCE_DATE;
+  const weekday = ["日", "月", "火", "水", "木", "金", "土"][today.getDay()];
+  const dateLabel = `${today.getMonth() + 1}月${today.getDate()}日 (${weekday})`;
+
   return (
     <div style={{ display: "flex", flexDirection: "column" }}>
+      {/* モバイル専用タイトル (PC は TopBar が担当) */}
+      <div
+        className="md:hidden"
+        style={{ padding: "4px 18px 14px" }}
+      >
+        <div style={{ display: "flex", alignItems: "baseline", justifyContent: "space-between" }}>
+          <div style={{ fontSize: 22, fontWeight: 700, color: "var(--mf-brand)", letterSpacing: -0.3 }}>
+            書く
+          </div>
+          <div style={{ fontSize: 12, color: "var(--mf-text-sub)", fontWeight: 500 }}>
+            {dateLabel}
+          </div>
+        </div>
+      </div>
+
       {/* インラインコンポーズ */}
       <div
         style={{
-          padding: "12px 28px",
+          padding: "12px 18px 12px",
           borderBottom: "0.5px solid var(--mf-line)",
         }}
+        className="md:px-[28px]"
       >
         <button
           type="button"

--- a/src/components/ui/ContextRail.tsx
+++ b/src/components/ui/ContextRail.tsx
@@ -143,145 +143,61 @@ const ReflectionRail = () => {
   const faces = faceRepository.listByUserId(user.id);
   const allActivities = activityRepository.listByUserId(user.id);
 
-  const refKey = REFERENCE_DATE.toISOString().slice(0, 10);
-  const weekAgo = new Date(REFERENCE_DATE);
-  weekAgo.setDate(REFERENCE_DATE.getDate() - 7);
-  const weekKey = weekAgo.toISOString().slice(0, 10);
-
   const thisMonth = REFERENCE_DATE.toISOString().slice(0, 7);
-  const lastMonthDate = new Date(REFERENCE_DATE);
-  lastMonthDate.setMonth(REFERENCE_DATE.getMonth() - 1);
-  const lastMonth = lastMonthDate.toISOString().slice(0, 7);
 
-  const thirtyAgo = new Date(REFERENCE_DATE);
-  thirtyAgo.setDate(REFERENCE_DATE.getDate() - 30);
-  const thirtyKey = thirtyAgo.toISOString().slice(0, 10);
-
-  // 今週のトップフェイス（直近7日）
-  const weekActs = allActivities.filter((a) => {
-    const d = a.createdAt.slice(0, 10);
-    return d >= weekKey && d <= refKey;
-  });
-  const weekFaceCounts = new Map<string, number>();
-  for (const act of weekActs) {
-    weekFaceCounts.set(act.faceId, (weekFaceCounts.get(act.faceId) ?? 0) + 1);
-  }
-  const topFaces = [...weekFaceCounts.entries()]
-    .sort((a, b) => b[1] - a[1])
-    .slice(0, 3)
-    .flatMap(([faceId, count]) => {
-      const face = faces.find((f) => f.id === faceId);
-      return face ? [{ face, count }] : [];
-    });
-
-  // 先月比で増加したフェイス
-  const thisMonthCount = new Map<string, number>();
-  const lastMonthCount = new Map<string, number>();
+  // 今月の各フェイスのシード数
+  const monthlyCountMap = new Map<string, number>();
   for (const act of allActivities) {
-    const m = act.createdAt.slice(0, 7);
-    if (m === thisMonth) thisMonthCount.set(act.faceId, (thisMonthCount.get(act.faceId) ?? 0) + 1);
-    if (m === lastMonth) lastMonthCount.set(act.faceId, (lastMonthCount.get(act.faceId) ?? 0) + 1);
+    if (act.createdAt.startsWith(thisMonth)) {
+      monthlyCountMap.set(act.faceId, (monthlyCountMap.get(act.faceId) ?? 0) + 1);
+    }
   }
-  const grownFaces = faces
-    .map((f) => ({ face: f, diff: (thisMonthCount.get(f.id) ?? 0) - (lastMonthCount.get(f.id) ?? 0) }))
-    .filter((x) => x.diff > 0)
-    .sort((a, b) => b.diff - a.diff)
-    .slice(0, 3);
 
-  // 停滞中フェイス（直近30日間に0投稿）
-  const stalledFaces = faces
-    .filter((f) => !allActivities.some((a) => a.faceId === f.id && a.createdAt.slice(0, 10) >= thirtyKey))
-    .slice(0, 3);
+  const facesWithCount = faces
+    .map((f) => ({ face: f, count: monthlyCountMap.get(f.id) ?? 0 }))
+    .filter(({ count }) => count > 0)
+    .sort((a, b) => b.count - a.count)
+    .slice(0, 5);
+
+  const maxCount = Math.max(...facesWithCount.map(({ count }) => count), 1);
 
   return (
     <div style={{ display: "flex", flexDirection: "column", gap: 14 }}>
-      <RailCard title="今週のフェイス">
-        {topFaces.length === 0 ? (
+      <RailCard title="フェイスについて">
+        <p style={{ fontSize: 12.5, lineHeight: 1.75, color: "var(--mf-text-sub)", margin: 0 }}>
+          フェイスは「あなたの多面性」のひとつ。
+          投稿したい内容にあったフェイスで書き、後から自分のために振り返ることができます。
+        </p>
+      </RailCard>
+
+      <RailCard title="アクティビティ" action="今月">
+        {facesWithCount.length === 0 ? (
           <p style={{ fontSize: 12, color: "var(--mf-text-muted)", margin: 0 }}>
-            今週はまだ記録がありません
+            今月はまだ記録がありません
           </p>
         ) : (
           <div style={{ display: "flex", flexDirection: "column", gap: 10 }}>
-            {topFaces.map(({ face, count }) => (
-              <div key={face.id} style={{ display: "flex", alignItems: "center", gap: 10 }}>
-                <FaceBadge face={face} size={28} radius={8} />
-                <span
-                  style={{
-                    flex: 1,
-                    fontSize: 12.5,
-                    color: "var(--mf-ink)",
-                    overflow: "hidden",
-                    textOverflow: "ellipsis",
-                    whiteSpace: "nowrap",
-                  }}
-                >
-                  {getFaceTitle(face)}
-                </span>
-                <span
-                  style={{
-                    fontSize: 11,
-                    fontWeight: 700,
-                    color: "var(--mf-accent)",
-                    background: "rgba(212,146,42,0.1)",
-                    padding: "2px 7px",
-                    borderRadius: 999,
-                    flexShrink: 0,
-                  }}
-                >
-                  {count}件
-                </span>
-              </div>
-            ))}
+            {facesWithCount.map(({ face, count }) => {
+              const color = getFaceColor(face.id);
+              const pct = (count / maxCount) * 100;
+              return (
+                <div key={face.id} style={{ display: "flex", alignItems: "center", gap: 10 }}>
+                  <FaceBadge face={face} size={24} radius={6} />
+                  <div style={{ flex: 1, minWidth: 0 }}>
+                    <div style={{ display: "flex", justifyContent: "space-between", alignItems: "baseline", marginBottom: 4 }}>
+                      <span style={{ fontSize: 12, fontWeight: 600, color: "var(--mf-text)" }}>{getFaceTitle(face)}</span>
+                      <span style={{ fontSize: 11, color: "var(--mf-text-muted)", fontWeight: 600 }}>{count}</span>
+                    </div>
+                    <div style={{ height: 4, background: "var(--mf-surface-tint)", borderRadius: 2, overflow: "hidden" }}>
+                      <div style={{ height: "100%", width: `${pct}%`, background: color, borderRadius: 2 }} />
+                    </div>
+                  </div>
+                </div>
+              );
+            })}
           </div>
         )}
       </RailCard>
-
-      {(grownFaces.length > 0 || stalledFaces.length > 0) && (
-        <RailCard title="変化の可視化">
-          <div style={{ display: "flex", flexDirection: "column", gap: 8 }}>
-            {grownFaces.map(({ face, diff }) => (
-              <div key={`grown-${face.id}`} style={{ display: "flex", alignItems: "center", gap: 8 }}>
-                <FaceBadge face={face} size={24} radius={7} />
-                <span
-                  style={{
-                    flex: 1,
-                    fontSize: 12,
-                    color: "var(--mf-ink)",
-                    overflow: "hidden",
-                    textOverflow: "ellipsis",
-                    whiteSpace: "nowrap",
-                  }}
-                >
-                  {getFaceTitle(face)}
-                </span>
-                <span style={{ fontSize: 11, color: "var(--mf-accent)", fontWeight: 600, flexShrink: 0 }}>
-                  ↑+{diff}
-                </span>
-              </div>
-            ))}
-            {stalledFaces.map((face) => (
-              <div key={`stalled-${face.id}`} style={{ display: "flex", alignItems: "center", gap: 8 }}>
-                <FaceBadge face={face} size={24} radius={7} />
-                <span
-                  style={{
-                    flex: 1,
-                    fontSize: 12,
-                    color: "var(--mf-text-sub)",
-                    overflow: "hidden",
-                    textOverflow: "ellipsis",
-                    whiteSpace: "nowrap",
-                  }}
-                >
-                  {getFaceTitle(face)}
-                </span>
-                <span style={{ fontSize: 11, color: "var(--mf-text-muted)", fontWeight: 600, flexShrink: 0 }}>
-                  停滞中
-                </span>
-              </div>
-            ))}
-          </div>
-        </RailCard>
-      )}
     </div>
   );
 };

--- a/src/components/ui/FaceNavItem.tsx
+++ b/src/components/ui/FaceNavItem.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import FaceBadge from "@/components/ui/FaceBadge";
+import { activityRepository } from "@/repositories/activity-repository";
 import type { Face } from "@/types/face";
 
 type Props = {
@@ -11,6 +12,7 @@ type Props = {
 
 const FaceNavItem = ({ face, activeFaceId, onClick }: Props) => {
   const isActive = activeFaceId === face.id;
+  const seedCount = activityRepository.listByFaceId(face.id).length;
 
   return (
     <li>
@@ -44,6 +46,15 @@ const FaceNavItem = ({ face, activeFaceId, onClick }: Props) => {
           }}
         >
           {face.name}
+        </span>
+        {face.isPrivate && (
+          <svg width={11} height={11} viewBox="0 0 14 14" fill="none" stroke="var(--mf-text-muted)" strokeWidth={1.5} strokeLinecap="round" strokeLinejoin="round">
+            <rect x={2.5} y={6} width={9} height={6.5} rx={1.2} />
+            <path d="M4.5 6V4a2.5 2.5 0 015 0v2" />
+          </svg>
+        )}
+        <span style={{ fontSize: 11, color: "var(--mf-text-muted)", fontWeight: 600, flexShrink: 0 }}>
+          {seedCount}
         </span>
       </button>
     </li>

--- a/src/components/ui/PostModal.tsx
+++ b/src/components/ui/PostModal.tsx
@@ -4,7 +4,7 @@ import { useEffect, useMemo, useRef, useState } from "react";
 import { faceRepository } from "@/repositories/face-repository";
 import { userRepository } from "@/repositories/user-repository";
 import FaceBadge from "./FaceBadge";
-import { getFaceTitle } from "@/lib/display";
+import { getFaceTitle, getFaceColor } from "@/lib/display";
 
 const MAX_IMAGES = 4;
 const MAX_LENGTH = 5000;
@@ -195,9 +195,8 @@ const PostModal = ({ isOpen, onClose, defaultFaceId }: Props) => {
       </div>
 
       {/* フェイス選択ピル */}
-      <div style={{ padding: "12px 18px 0", flexShrink: 0 }}>
+      <div style={{ padding: "4px 18px 14px", flexShrink: 0 }}>
         <div style={{ display: "flex", alignItems: "center", gap: 8 }}>
-          <span style={{ fontSize: 11, color: "var(--mf-text-muted)", fontWeight: 600 }}>このフェイスに書く</span>
           <button
             type="button"
             onClick={() => setShowFacePicker((p) => !p)}
@@ -205,21 +204,23 @@ const PostModal = ({ isOpen, onClose, defaultFaceId }: Props) => {
               display: "inline-flex",
               alignItems: "center",
               gap: 7,
-              padding: "5px 10px 5px 6px",
-              background: "var(--mf-surface-tint)",
+              padding: "6px 12px 6px 6px",
+              background: selectedFace ? `${getFaceColor(selectedFace.id)}12` : "var(--mf-surface-tint)",
               borderRadius: 999,
               border: "none",
               cursor: "pointer",
+              whiteSpace: "nowrap",
             }}
           >
             {selectedFace && <FaceBadge face={selectedFace} size={22} radius={6} />}
-            <span style={{ fontSize: 13, fontWeight: 700, color: "var(--mf-brand)" }}>
+            <span style={{ fontSize: 13, fontWeight: 700, color: selectedFace ? getFaceColor(selectedFace.id) : "var(--mf-text-muted)" }}>
               {selectedFace ? getFaceTitle(selectedFace) : "フェイスを選択"}
             </span>
-            <svg width={12} height={12} viewBox="0 0 12 12" fill="none" stroke="var(--mf-text-muted)" strokeWidth={1.5} strokeLinecap="round">
-              <path d="M2 4l4 4 4-4" />
+            <svg width={9} height={9} viewBox="0 0 10 7" fill="none" stroke={selectedFace ? getFaceColor(selectedFace.id) : "var(--mf-text-muted)"} strokeWidth={1.6} strokeLinecap="round">
+              <path d="M1 1l4 4 4-4" />
             </svg>
           </button>
+          <span style={{ fontSize: 11.5, color: "var(--mf-text-muted)" }}>このフェイスに書く</span>
         </div>
 
         {/* フェイス選択ドロップダウン */}
@@ -425,12 +426,11 @@ const PostModal = ({ isOpen, onClose, defaultFaceId }: Props) => {
         <div style={{ flex: 1 }} />
 
         {/* 文字数カウント + 下書き */}
-        <span style={{ fontSize: 11, color: "var(--mf-text-faint)" }}>
-          {text.length} / {MAX_LENGTH.toLocaleString()}
-        </span>
-        <span style={{ fontSize: 11, color: "var(--mf-text-faint)" }}>
-          下書き保存済
-        </span>
+        <div style={{ display: "flex", alignItems: "center", gap: 10, fontSize: 11.5, color: "var(--mf-text-muted)", whiteSpace: "nowrap" }}>
+          <span>{text.length} 文字</span>
+          <div style={{ width: 4, height: 4, borderRadius: "50%", background: "var(--mf-line-soft)" }} />
+          <span>下書き保存済</span>
+        </div>
       </div>
     </div>
   );

--- a/src/components/ui/SideNav.tsx
+++ b/src/components/ui/SideNav.tsx
@@ -310,6 +310,11 @@ const SideNav = () => {
             >
               {currentUser.name}
             </div>
+            {currentUser.handle && (
+              <div style={{ fontSize: 11, color: "var(--mf-text-muted)", textAlign: "left" }}>
+                @{currentUser.handle}
+              </div>
+            )}
           </div>
           <svg width={14} height={14} viewBox="0 0 14 14" fill="none" stroke="var(--mf-text-faint)" strokeWidth={1.5} strokeLinecap="round">
             <path d="M2 5l5 4 5-4" />


### PR DESCRIPTION
## 概要

Claude Designファイルと現在の実装を比較し、未対応だった差分を修正しました。FaceCard、ReflectionRail、SideNav（ユーザーピル）、PostModal、HomeClientの5つのコンポーネントを対象に、デザイン仕様に準拠した修正を行っています。

## 関連Issue

Refs #104, #105, #108, #112

## 変更点

- **FacesClient.tsx (FaceCard)**
  - 非公開バッジをカラーバンド内に移動し、`backdropFilter: blur(8px)` でガラス調スタイルに変更
  - 非公開でない場合は `···` メニューアイコンをカラーバンド右上に表示
  - `+N/月` の色をアクセントカラーからface固有色に変更
  - カード本文レイアウトを `justifyContent: space-between` に整理

- **ContextRail.tsx (ReflectionRail)**
  - 「今週のフェイス」「変化の可視化」「停滞中」セクションをデザイン仕様に差し替え
  - 「フェイスについて」説明テキストカードを追加
  - 「アクティビティ 今月」セクション: フェイスごとの横方向プログレスバー（face固有色、高さ4px）を実装

- **FaceNavItem.tsx**
  - 非公開フェイスにロックアイコンを追加
  - シード数をアイテム右端に表示

- **SideNav.tsx**
  - ユーザーピルにハンドル名（`@handle`）を表示

- **PostModal.tsx**
  - フェイスピルの背景色・テキスト色・シェブロン色をface固有色に対応
  - 文字数カウント表示を「N 文字」＋「下書き保存済」形式に変更
  - セクションパディングを調整

- **HomeClient.tsx**
  - モバイル専用の「書く」タイトルと日付をインラインコンポーズの上部に追加

## 動作確認

- [ ] FaceCard: カラーバンドに非公開バッジ・メニューアイコンが表示される
- [ ] ReflectionRail: 「フェイスについて」カードと「アクティビティ 今月」バーが表示される
- [ ] SideNavのフェイスリスト: ロックアイコンとシード数が表示される
- [ ] SideNavのユーザーピル: ハンドル名が表示される
- [ ] PostModal: フェイス色に対応したピルスタイル、文字数表示が正しい
- [ ] HomeClient (モバイル): 「書く」タイトルと日付が表示される
