### PR TITLE
fix(ui): SideNav投稿ボタンのPostModal連携・PostModalアイコン改善

### DIFF
--- a/src/components/ui/PostModal.tsx
+++ b/src/components/ui/PostModal.tsx
@@ -362,68 +362,92 @@ const PostModal = ({ isOpen, onClose, defaultFaceId }: Props) => {
           padding: "10px 18px",
           display: "flex",
           alignItems: "center",
-          gap: 14,
+          justifyContent: "space-between",
           paddingBottom: "calc(10px + env(safe-area-inset-bottom))",
         }}
       >
-        {/* 画像添付 */}
-        <input
-          ref={fileInputRef}
-          type="file"
-          accept="image/*"
-          multiple
-          style={{ display: "none" }}
-          onChange={handleFileChange}
-        />
-        <button
-          type="button"
-          disabled={images.length >= MAX_IMAGES}
-          onClick={() => fileInputRef.current?.click()}
-          aria-label="画像を添付"
-          style={{
-            width: 34,
-            height: 34,
-            display: "flex",
-            alignItems: "center",
-            justifyContent: "center",
-            borderRadius: "50%",
-            background: "none",
-            border: "none",
-            cursor: images.length >= MAX_IMAGES ? "not-allowed" : "pointer",
-            color: images.length >= MAX_IMAGES ? "var(--mf-text-faint)" : "var(--mf-text-sub)",
-          }}
-        >
-          <svg width={20} height={20} viewBox="0 0 20 20" fill="none" stroke="currentColor" strokeWidth={1.6} strokeLinecap="round" strokeLinejoin="round">
-            <rect x={3} y={3} width={14} height={14} rx={2} />
-            <circle cx={7} cy={7.5} r={1.2} />
-            <path d="M3 14l4-4 4 4 3-3 3 3" />
-          </svg>
-        </button>
+        {/* 画像添付 + リンクボタン */}
+        <div style={{ display: "flex", alignItems: "center", gap: 22 }}>
+          <input
+            ref={fileInputRef}
+            type="file"
+            accept="image/*"
+            multiple
+            style={{ display: "none" }}
+            onChange={handleFileChange}
+          />
+          <button
+            type="button"
+            disabled={images.length >= MAX_IMAGES}
+            onClick={() => fileInputRef.current?.click()}
+            aria-label="画像を添付"
+            style={{
+              position: "relative",
+              width: 34,
+              height: 34,
+              display: "flex",
+              alignItems: "center",
+              justifyContent: "center",
+              borderRadius: "50%",
+              background: "none",
+              border: "none",
+              cursor: images.length >= MAX_IMAGES ? "not-allowed" : "pointer",
+              color: images.length >= MAX_IMAGES ? "var(--mf-text-faint)" : "var(--mf-brand)",
+            }}
+          >
+            <svg width={20} height={20} viewBox="0 0 20 20" fill="none" stroke="currentColor" strokeWidth={1.6} strokeLinecap="round" strokeLinejoin="round">
+              <rect x={3} y={3} width={14} height={14} rx={2} />
+              <circle cx={7} cy={7.5} r={1.2} />
+              <path d="M3 14l4-4 4 4 3-3 3 3" />
+            </svg>
+            {images.length > 0 && (
+              <span
+                style={{
+                  position: "absolute",
+                  top: 1,
+                  right: 1,
+                  background: "var(--mf-accent)",
+                  color: "#fff",
+                  borderRadius: 999,
+                  fontSize: 9,
+                  fontWeight: 700,
+                  minWidth: 14,
+                  height: 14,
+                  padding: "0 3px",
+                  display: "flex",
+                  alignItems: "center",
+                  justifyContent: "center",
+                  boxSizing: "border-box",
+                }}
+              >
+                {images.length}
+              </span>
+            )}
+          </button>
 
-        {/* リンクボタン */}
-        <button
-          type="button"
-          aria-label="リンクを追加"
-          style={{
-            width: 34,
-            height: 34,
-            display: "flex",
-            alignItems: "center",
-            justifyContent: "center",
-            borderRadius: "50%",
-            background: "none",
-            border: "none",
-            cursor: "pointer",
-            color: "var(--mf-text-sub)",
-          }}
-        >
-          <svg width={18} height={18} viewBox="0 0 16 16" fill="none" stroke="currentColor" strokeWidth={1.5} strokeLinecap="round" strokeLinejoin="round">
-            <path d="M6.5 9.5a3.54 3.54 0 005 0l2-2a3.54 3.54 0 00-5-5l-1 1" />
-            <path d="M9.5 6.5a3.54 3.54 0 00-5 0l-2 2a3.54 3.54 0 005 5l1-1" />
-          </svg>
-        </button>
-
-        <div style={{ flex: 1 }} />
+          {/* リンクボタン */}
+          <button
+            type="button"
+            aria-label="リンクを追加"
+            style={{
+              width: 34,
+              height: 34,
+              display: "flex",
+              alignItems: "center",
+              justifyContent: "center",
+              borderRadius: "50%",
+              background: "none",
+              border: "none",
+              cursor: "pointer",
+              color: "var(--mf-brand)",
+            }}
+          >
+            <svg width={18} height={18} viewBox="0 0 16 16" fill="none" stroke="currentColor" strokeWidth={1.5} strokeLinecap="round" strokeLinejoin="round">
+              <path d="M6.5 9.5a3.54 3.54 0 005 0l2-2a3.54 3.54 0 00-5-5l-1 1" />
+              <path d="M9.5 6.5a3.54 3.54 0 00-5 0l-2 2a3.54 3.54 0 005 5l1-1" />
+            </svg>
+          </button>
+        </div>
 
         {/* 文字数カウント + 下書き */}
         <div style={{ display: "flex", alignItems: "center", gap: 10, fontSize: 11.5, color: "var(--mf-text-muted)", whiteSpace: "nowrap" }}>

--- a/src/components/ui/SideNav.tsx
+++ b/src/components/ui/SideNav.tsx
@@ -8,6 +8,7 @@ import FaceBadge from "@/components/ui/FaceBadge";
 import FaceNavItem from "@/components/ui/FaceNavItem";
 import AccountMenu from "@/components/ui/AccountMenu";
 import CreateFaceModal from "@/components/face/CreateFaceModal";
+import PostModal from "@/components/ui/PostModal";
 import { faceRepository } from "@/repositories/face-repository";
 import { userRepository } from "@/repositories/user-repository";
 import { notificationRepository } from "@/repositories/notification-repository";
@@ -64,6 +65,7 @@ const SideNav = () => {
   const pathname = usePathname();
   const router = useRouter();
   const [isCreateModalOpen, setIsCreateModalOpen] = useState(false);
+  const [isPostModalOpen, setIsPostModalOpen] = useState(false);
   const [menuOpen, setMenuOpen] = useState(false);
 
   const currentUser = userRepository.getCurrentUser();
@@ -179,7 +181,7 @@ const SideNav = () => {
         {/* 投稿ボタン */}
         <button
           type="button"
-          onClick={() => {}}
+          onClick={() => setIsPostModalOpen(true)}
           style={{
             marginTop: 18,
             padding: "13px 16px",
@@ -328,6 +330,11 @@ const SideNav = () => {
         isOpen={isCreateModalOpen}
         onClose={() => setIsCreateModalOpen(false)}
         onCreate={() => setIsCreateModalOpen(false)}
+      />
+
+      <PostModal
+        isOpen={isPostModalOpen}
+        onClose={() => setIsPostModalOpen(false)}
       />
     </>
   );


### PR DESCRIPTION
## 概要

SideNav の投稿ボタンが機能しない問題と、PostModal のボトムバーアイコンのデザイン差分を修正しました。

## 関連Issue

Closes #121
Closes #125

## 変更点

- **SideNav.tsx**
  - `isPostModalOpen` state を追加
  - 「新しいシードを書く」ボタンの `onClick` を `() => {}` から `() => setIsPostModalOpen(true)` に変更
  - `PostModal` をコンポーネント末尾にマウント
  - `PostModal` をインポートに追加

- **PostModal.tsx**
  - 画像アイコン・リンクアイコンの色を `var(--mf-text-sub)` → `var(--mf-brand)` に変更
  - ボトムバーのレイアウトを `gap: 14` → `justifyContent: space-between` に変更（左: アイコン群、右: 文字数表示）
  - 画像アイコンとリンクアイコンをラップする `div` を追加し `gap: 22` を設定
  - 画像が添付されている場合（`images.length > 0`）、アイコン右上にアクセントカラーのバッジカウントを表示

## 動作確認

- [ ] SideNav（PC）の「新しいシードを書く」ボタンをクリックすると PostModal が開く
- [ ] PostModal の画像アイコン・リンクアイコンが Brand カラー（紺色）で表示される
- [ ] 画像を添付するとアイコン右上に添付枚数バッジが表示される
- [ ] バッジはアクセントカラー（ゴールド）で表示される
- [ ] モバイルの HomeClient からの PostModal 起動は従来通り動作する
