### PR TITLE
fix(ui): Writing・Reflection・Collection タブのページタイトルとヘッダーをデザイン仕様に準拠

### DIFF
--- a/src/components/face/FacesClient.tsx
+++ b/src/components/face/FacesClient.tsx
@@ -76,10 +76,35 @@ const FacesClient = ({ initialFaces }: Props) => {
     name: "名前順",
   };
 
+  const totalSeeds = useMemo(
+    () => Array.from(faceStats.values()).reduce((sum, s) => sum + s.total, 0),
+    [faceStats]
+  );
+
   return (
     <main style={{ display: "flex", flexDirection: "column", paddingBottom: 24 }}>
+      {/* ページタイトル */}
+      <div style={{ padding: "4px 18px 14px" }}>
+        <div style={{ display: "flex", alignItems: "baseline", justifyContent: "space-between" }}>
+          <div
+            style={{
+              fontSize: 22,
+              fontWeight: 700,
+              color: "var(--mf-brand)",
+              letterSpacing: -0.3,
+              fontFamily: "var(--mf-font-sans)",
+            }}
+          >
+            振り返り
+          </div>
+          <div style={{ fontSize: 12, color: "var(--mf-text-sub)", fontWeight: 500 }}>
+            {faces.length} フェイス · {totalSeeds} シード
+          </div>
+        </div>
+      </div>
+
       {/* 検索バー */}
-      <div style={{ padding: "12px 20px 8px" }}>
+      <div style={{ padding: "0 18px 8px" }}>
         <div
           style={{
             display: "flex",

--- a/src/components/home/HomeClient.tsx
+++ b/src/components/home/HomeClient.tsx
@@ -192,21 +192,28 @@ const HomeClient = () => {
       <div
         style={{
           display: "flex",
-          alignItems: "center",
+          alignItems: "baseline",
           justifyContent: "space-between",
-          padding: "14px 28px 6px",
+          padding: "20px 18px 4px",
         }}
       >
         <span
           style={{
-            fontSize: 11,
+            fontSize: 13.5,
             fontWeight: 700,
-            letterSpacing: 0.6,
-            textTransform: "uppercase",
-            color: "var(--mf-text-muted)",
+            letterSpacing: 0.2,
+            color: "var(--mf-brand)",
           }}
         >
           最近のシード
+        </span>
+        <span
+          style={{
+            fontSize: 11.5,
+            color: "var(--mf-text-muted)",
+          }}
+        >
+          すべて見る
         </span>
       </div>
 

--- a/src/components/subscriptions/SubscriptionFeed.tsx
+++ b/src/components/subscriptions/SubscriptionFeed.tsx
@@ -56,6 +56,30 @@ const SubscriptionFeed = () => {
 
   return (
     <div>
+      {/* ページタイトル */}
+      <div style={{ padding: "4px 18px 14px" }}>
+        <div style={{ display: "flex", alignItems: "baseline", justifyContent: "space-between" }}>
+          <div
+            style={{
+              fontSize: 22,
+              fontWeight: 700,
+              color: "var(--mf-brand)",
+              letterSpacing: -0.3,
+              fontFamily: "var(--mf-font-sans)",
+            }}
+          >
+            蒐集
+          </div>
+          {subscribedFaces.length === 0 ? (
+            <div style={{ fontSize: 12, color: "var(--mf-text-sub)" }}>気になるフェイスを見つける</div>
+          ) : (
+            <svg width={18} height={18} viewBox="0 0 18 18" fill="none" stroke="var(--mf-brand)" strokeWidth={1.6} strokeLinecap="round" strokeLinejoin="round">
+              <circle cx={8} cy={8} r={5.5} /><path d="M12.2 12.2L16 16" />
+            </svg>
+          )}
+        </div>
+      </div>
+
       {/* タブ */}
       <div
         style={{
@@ -106,6 +130,7 @@ const SubscriptionFeed = () => {
             >
               {subscribedFaces.map((face) => {
                 const hasUnread = subscribedActivities.some((a) => a.faceId === face.id);
+                const owner = userMap.get(face.userId);
                 return (
                   <div
                     key={face.id}
@@ -113,34 +138,34 @@ const SubscriptionFeed = () => {
                       display: "flex",
                       flexDirection: "column",
                       alignItems: "center",
-                      gap: 5,
+                      gap: 6,
                       flexShrink: 0,
+                      width: 52,
                     }}
                   >
                     <div
                       style={{
-                        padding: 2,
-                        borderRadius: 13,
-                        background: hasUnread
-                          ? "linear-gradient(135deg, var(--mf-accent), var(--mf-accent-soft))"
-                          : "transparent",
-                        border: hasUnread ? "none" : "1.5px solid var(--mf-line)",
+                        borderRadius: 12,
+                        boxShadow: hasUnread
+                          ? "0 0 0 2px var(--mf-bg-light), 0 0 0 3.5px var(--mf-accent)"
+                          : "none",
+                        flexShrink: 0,
                       }}
                     >
-                      <FaceBadge face={face} size={44} radius={11} />
+                      <FaceBadge face={face} size={46} radius={12} />
                     </div>
                     <span
                       style={{
-                        fontSize: 9.5,
+                        fontSize: 10,
                         color: "var(--mf-text-sub)",
-                        maxWidth: 50,
+                        maxWidth: 52,
                         overflow: "hidden",
                         textOverflow: "ellipsis",
                         whiteSpace: "nowrap",
                         textAlign: "center",
                       }}
                     >
-                      {getFaceTitle(face)}
+                      {owner?.handle ?? getFaceTitle(face)}
                     </span>
                   </div>
                 );
@@ -162,11 +187,13 @@ const SubscriptionFeed = () => {
                   {acts.map((activity, i) => {
                     const face = faceMap.get(activity.faceId);
                     if (!face) return null;
+                    const owner = userMap.get(activity.userId);
                     return (
                       <SeedRow
                         key={activity.id}
                         activity={activity}
                         face={face}
+                        handle={owner?.handle}
                         onClick={() => openActivity(activity.id)}
                         noBorder={i === acts.length - 1}
                       />
@@ -180,59 +207,60 @@ const SubscriptionFeed = () => {
       )}
 
       {activeTab === "subscriptions" && (
-        <div style={{ padding: "16px 28px", display: "flex", flexDirection: "column", gap: 10 }}>
+        <div>
           {subscribedFaces.length === 0 ? (
             <EmptyState />
           ) : (
-            subscribedFaces.map((face) => {
+            subscribedFaces.map((face, i) => {
               const owner = userMap.get(face.userId);
               const faceActivities = subscribedActivities.filter((a) => a.faceId === face.id);
               return (
-                <Link
+                <div
                   key={face.id}
-                  href={`/faces/${face.id}`}
                   style={{
                     display: "flex",
                     alignItems: "center",
                     gap: 12,
-                    padding: "12px 14px",
-                    borderRadius: 12,
-                    background: "var(--mf-surface-card)",
-                    border: "0.5px solid var(--mf-line)",
-                    textDecoration: "none",
+                    padding: "12px 18px",
+                    borderBottom: i < subscribedFaces.length - 1 ? "0.5px solid var(--mf-line-soft)" : "none",
                   }}
                 >
-                  <FaceBadge face={face} size={40} radius={11} />
-                  <div style={{ flex: 1, minWidth: 0 }}>
-                    <div
-                      style={{
-                        fontSize: 13.5,
-                        fontWeight: 700,
-                        color: "var(--mf-brand)",
-                        overflow: "hidden",
-                        textOverflow: "ellipsis",
-                        whiteSpace: "nowrap",
-                      }}
-                    >
-                      {getFaceTitle(face)}
-                    </div>
-                    {owner && (
-                      <div style={{ fontSize: 11.5, color: "var(--mf-text-muted)", marginTop: 2 }}>
-                        {owner.name}
+                  <Link href={`/faces/${face.id}`} style={{ display: "flex", alignItems: "center", gap: 12, flex: 1, minWidth: 0, textDecoration: "none" }}>
+                    <FaceBadge face={face} size={42} radius={11} />
+                    <div style={{ flex: 1, minWidth: 0 }}>
+                      <div style={{ display: "flex", alignItems: "baseline", gap: 6, whiteSpace: "nowrap" }}>
+                        <span style={{ fontSize: 14, fontWeight: 700, color: "var(--mf-brand)" }}>
+                          {getFaceTitle(face)}
+                        </span>
+                        {owner?.handle && (
+                          <span style={{ fontSize: 11.5, color: "var(--mf-text-muted)" }}>
+                            @{owner.handle}
+                          </span>
+                        )}
                       </div>
-                    )}
-                  </div>
-                  <div
+                      <div style={{ marginTop: 2, fontSize: 11.5, color: "var(--mf-text-sub)", overflow: "hidden", textOverflow: "ellipsis", whiteSpace: "nowrap" }}>
+                        {face.description ?? ""} · {faceActivities.length} シード
+                      </div>
+                    </div>
+                  </Link>
+                  <button
+                    type="button"
                     style={{
-                      fontSize: 11,
-                      color: "var(--mf-text-muted)",
-                      textAlign: "right",
+                      padding: "7px 14px",
+                      borderRadius: 999,
+                      border: "1px solid var(--mf-brand)",
+                      color: "var(--mf-brand)",
+                      background: "transparent",
+                      fontSize: 12,
+                      fontWeight: 700,
+                      whiteSpace: "nowrap",
+                      cursor: "pointer",
                       flexShrink: 0,
                     }}
                   >
-                    {faceActivities.length} シード
-                  </div>
-                </Link>
+                    サブスク中
+                  </button>
+                </div>
               );
             })
           )}
@@ -242,50 +270,134 @@ const SubscriptionFeed = () => {
   );
 };
 
+const RECOMMENDED_FACES = [
+  { color: "#5B8DB8", kanji: "読", name: "読書",    handle: "h_maru",     subs: 412, desc: "読みながら考えたこと" },
+  { color: "#7B6B9E", kanji: "映", name: "映画断片", handle: "sayaka_t",   subs: 287, desc: "観終わってからしばらく" },
+  { color: "#A89050", kanji: "珈", name: "朝の珈琲", handle: "kettle_co",  subs: 198, desc: "一杯目のメモ" },
+  { color: "#B06B7A", kanji: "夜", name: "夜更けに", handle: "yorunoyoru", subs: 156, desc: "23時以降のひとりごと" },
+];
+
 const EmptyState = () => (
-  <div
-    style={{
-      margin: "32px 28px",
-      padding: "28px 20px",
-      borderRadius: 16,
-      background: "var(--mf-bg-dark)",
-      display: "flex",
-      flexDirection: "column",
-      alignItems: "center",
-      gap: 12,
-      textAlign: "center",
-    }}
-  >
+  <div>
+    {/* Quiet Feed バナー */}
     <div
       style={{
-        fontSize: 13,
-        fontWeight: 700,
-        color: "rgba(248,246,241,0.9)",
-        letterSpacing: 0.3,
+        margin: "20px 18px 0",
+        padding: "24px 22px",
+        borderRadius: 16,
+        background: "var(--mf-bg-dark)",
+        position: "relative",
+        overflow: "hidden",
       }}
     >
-      Quiet Feed
+      <div
+        style={{
+          position: "absolute",
+          top: -50,
+          right: -50,
+          width: 140,
+          height: 140,
+          borderRadius: "50%",
+          background: "radial-gradient(circle at 35% 35%, rgba(248,246,241,0.18) 0%, rgba(248,246,241,0.04) 60%, transparent 100%)",
+          pointerEvents: "none",
+        }}
+      />
+      <div style={{ display: "flex", alignItems: "center", gap: 6, marginBottom: 8 }}>
+        <div style={{ width: 4, height: 4, borderRadius: "50%", background: "var(--mf-accent)" }} />
+        <div style={{ fontSize: 10.5, color: "var(--mf-accent)", letterSpacing: 1, textTransform: "uppercase" as const, fontWeight: 700 }}>
+          Quiet Feed
+        </div>
+      </div>
+      <div style={{ fontSize: 17, lineHeight: 1.55, fontWeight: 700, color: "rgba(248,246,241,0.92)", letterSpacing: 0.2 }}>
+        まだ、誰のフェイスも<br />サブスクライブしていない。
+      </div>
+      <div style={{ marginTop: 8, fontSize: 12, lineHeight: 1.7, color: "rgba(248,246,241,0.6)" }}>
+        気になるフェイスを1つだけ、まず選んでみる。<br />
+        通知の重みを大切にする設計です。
+      </div>
     </div>
-    <p style={{ fontSize: 12, color: "rgba(248,246,241,0.5)", margin: 0, lineHeight: 1.7 }}>
-      まだサブスクしているフェイスがありません。
-      <br />
-      気になるフェイスを見つけて、フィードを育てましょう。
-    </p>
-    <Link
-      href="/search"
-      style={{
-        marginTop: 4,
-        padding: "8px 20px",
-        borderRadius: 999,
-        background: "var(--mf-accent)",
-        color: "#fff",
-        fontSize: 13,
-        fontWeight: 700,
-        textDecoration: "none",
-      }}
-    >
-      フェイスを探す
-    </Link>
+
+    {/* おすすめのフェイス */}
+    <div style={{ marginTop: 20 }}>
+      <div style={{ padding: "0 18px", display: "flex", alignItems: "center", gap: 6, marginBottom: 10 }}>
+        <div style={{ fontSize: 13, fontWeight: 700, color: "var(--mf-brand)", letterSpacing: 0.2 }}>おすすめのフェイス</div>
+        <div style={{ fontSize: 11, color: "var(--mf-text-muted)" }}>· あなたに合いそうな</div>
+      </div>
+
+      {RECOMMENDED_FACES.map((r, i) => (
+        <div
+          key={r.handle}
+          style={{
+            padding: "12px 18px",
+            borderBottom: i < RECOMMENDED_FACES.length - 1 ? `0.5px solid var(--mf-line-soft)` : "none",
+            display: "flex",
+            gap: 12,
+            alignItems: "center",
+          }}
+        >
+          <div
+            style={{
+              width: 42,
+              height: 42,
+              borderRadius: 11,
+              background: r.color,
+              color: "#fff",
+              fontFamily: "var(--mf-font-serif)",
+              fontSize: 20,
+              fontWeight: 500,
+              display: "flex",
+              alignItems: "center",
+              justifyContent: "center",
+              flexShrink: 0,
+            }}
+          >
+            {r.kanji}
+          </div>
+          <div style={{ flex: 1, minWidth: 0 }}>
+            <div style={{ display: "flex", alignItems: "baseline", gap: 6, whiteSpace: "nowrap" }}>
+              <div style={{ fontSize: 14, fontWeight: 700, color: "var(--mf-brand)" }}>{r.name}</div>
+              <div style={{ fontSize: 11.5, color: "var(--mf-text-muted)" }}>@{r.handle}</div>
+            </div>
+            <div style={{ marginTop: 2, fontSize: 11.5, color: "var(--mf-text-sub)", overflow: "hidden", textOverflow: "ellipsis", whiteSpace: "nowrap" }}>
+              {r.desc} · {r.subs} サブスク
+            </div>
+          </div>
+          <button
+            type="button"
+            style={{
+              padding: "7px 14px",
+              borderRadius: 999,
+              background: i === 0 ? "var(--mf-brand)" : "transparent",
+              border: i === 0 ? "none" : "1px solid var(--mf-brand)",
+              color: i === 0 ? "#F8F6F1" : "var(--mf-brand)",
+              fontSize: 12,
+              fontWeight: 700,
+              whiteSpace: "nowrap",
+              cursor: "pointer",
+              flexShrink: 0,
+            }}
+          >
+            サブスク
+          </button>
+        </div>
+      ))}
+
+      <div style={{ padding: "14px 18px 0" }}>
+        <div
+          style={{
+            padding: 11,
+            border: "1px dashed var(--mf-line)",
+            borderRadius: 10,
+            textAlign: "center",
+            fontSize: 12,
+            color: "var(--mf-text-sub)",
+            fontWeight: 600,
+          }}
+        >
+          人気フェイスをもっと見る →
+        </div>
+      </div>
+    </div>
   </div>
 );
 


### PR DESCRIPTION
## 概要

Claude Design ファイルとの実装差分を解消するため、Writing・Reflection・Collection タブのページタイトルエリアとセクションヘッダーを仕様準拠に修正した。

## 関連 Issue

Closes #122
Closes #123
Closes #124

## 変更点

### Writing タブ（HomeClient.tsx）
- 「最近のシード」セクションヘッダーのスタイルをデザイン仕様に合わせて変更
  - `font-size: 11 / uppercase` → `13.5 / brand color`
  - `padding: "14px 28px 6px"` → `"20px 18px 4px"`
  - `alignItems: center` → `baseline`
- 右側に「すべて見る」テキストを追加

### Reflection タブ（FacesClient.tsx）
- ページ上部にタイトルエリアを追加（「振り返り」22px bold + フェイス数・シード数のサマリー）
- 検索バーの padding を `"12px 20px 8px"` → `"0 18px 8px"` に調整
- `totalSeeds` を `useMemo` で算出するロジックを追加

### Collection タブ（SubscriptionFeed.tsx）
- ページ上部にタイトルエリアを追加（「蒐集」22px bold + 検索アイコン / 未サブスク時はキャッチコピー）
- タイムライン行のフェイスアイコンリング表示をグラデーション枠 → `box-shadow` によるアクセントリングに変更（FaceBadge が `style` prop 非対応のためラッパー div で対応）
- タイムラインの FaceBadge 下ラベルを face タイトル → `@handle`（オーナーのハンドル名）表示に変更
- SeedRow に `handle` prop を渡してオーナー表示を追加
- サブスク一覧タブのレイアウトをカード形式 → リスト行形式（border-bottom 区切り）に変更
  - フェイス名・@handle・説明・シード数を横並びで表示
  - 「サブスク中」アウトラインボタンを右端に配置
- EmptyState をデザイン仕様に沿って全面リデザイン
  - "Quiet Feed" ダークバナー（ラジアルグラデーション装飾付き）
  - おすすめフェイス一覧（モックデータ 4 件）：漢字バッジ・名前・@handle・説明・サブスク数
  - 先頭のみフィルドボタン、残りはアウトラインボタン
  - 「人気フェイスをもっと見る →」破線ボタン

## 動作確認

- [ ] Writing タブで「最近のシード」ヘッダーが brand color・大きめフォントで表示される
- [ ] Reflection タブ上部に「振り返り」タイトルとフェイス数・シード数が表示される
- [ ] Collection タブ上部に「蒐集」タイトルと検索アイコン（未サブスク時はキャッチコピー）が表示される
- [ ] サブスク済みフェイスのアイコンに accent color のリングが表示される
- [ ] サブスク一覧タブがリスト行形式で表示される
- [ ] サブスク未登録時に EmptyState（Quiet Feed バナー＋おすすめフェイス）が表示される
- [ ] TypeScript エラーなし（`npx tsc --noEmit` 通過済み）
