### PR TITLE
fix(ui): Writing tab コンポーズエリアのパディング・borderRadius・OnThisDay パディングをデザイン仕様に修正

### DIFF
--- a/src/components/home/HomeClient.tsx
+++ b/src/components/home/HomeClient.tsx
@@ -56,13 +56,7 @@ const HomeClient = () => {
       </div>
 
       {/* インラインコンポーズ */}
-      <div
-        style={{
-          padding: "12px 18px 12px",
-          borderBottom: "0.5px solid var(--mf-line)",
-        }}
-        className="md:px-[28px]"
-      >
+      <div style={{ padding: "0 18px" }}>
         <button
           type="button"
           onClick={() => setIsModalOpen(true)}
@@ -72,7 +66,7 @@ const HomeClient = () => {
             alignItems: "center",
             gap: 10,
             padding: "10px 14px",
-            borderRadius: 14,
+            borderRadius: 16,
             background: "var(--mf-surface)",
             border: "0.5px solid var(--mf-line)",
             cursor: "pointer",
@@ -116,7 +110,7 @@ const HomeClient = () => {
         const yearsAgo = REFERENCE_DATE.getFullYear() - year;
         const mmdd = act.createdAt.slice(5, 10).replace("-", "/");
         return (
-          <div style={{ padding: "22px 28px 6px" }}>
+          <div style={{ padding: "22px 18px 6px" }}>
             {/* ヘッダー: アクセントライン + ON THIS DAY + N年前の今日 */}
             <div
               style={{


### PR DESCRIPTION
## 概要

Writing タブのコンポーズエリアと OnThisDay セクションのパディング・borderRadius をデザイン仕様（`mf-writing.jsx` の `WritingDefault`）に準拠させる。

## 関連 Issue

Closes #128

## 変更点

### `src/components/home/HomeClient.tsx`

- コンポーズエリアのラッパー div: `padding: "12px 18px 12px"` + `borderBottom` → `padding: "0 18px"`、borderBottom 除去
- `className="md:px-[28px]"` を削除（PC 幅の上書きも不要に）
- コンポーズボックスの `borderRadius: 14` → `16`（デザイン仕様値）
- OnThisDay セクションの水平パディング: `28px` → `18px`（デザイン仕様値）

## 動作確認

- [ ] Writing タブのコンポーズボックスが左右 18px の余白で表示される
- [ ] コンポーズボックスの角が borderRadius 16 でレンダリングされる
- [ ] OnThisDay セクションの左右余白が 18px に揃っている
- [ ] TypeScript エラーなし（`npx tsc --noEmit` 通過済み）
