### PR TITLE
fix(ui): SideNav ユーザーピルアイコンと PostModal キャンバスパディングをデザイン仕様に修正

### DIFF
--- a/src/components/ui/PostModal.tsx
+++ b/src/components/ui/PostModal.tsx
@@ -271,7 +271,7 @@ const PostModal = ({ isOpen, onClose, defaultFaceId }: Props) => {
       </div>
 
       {/* 書き込みキャンバス */}
-      <div style={{ flex: 1, padding: "16px 18px", overflowY: "auto" }}>
+      <div style={{ flex: 1, padding: "4px 22px", overflowY: "auto" }}>
         <textarea
           ref={textareaRef}
           value={text}

--- a/src/components/ui/SideNav.tsx
+++ b/src/components/ui/SideNav.tsx
@@ -318,8 +318,8 @@ const SideNav = () => {
               </div>
             )}
           </div>
-          <svg width={14} height={14} viewBox="0 0 14 14" fill="none" stroke="var(--mf-text-faint)" strokeWidth={1.5} strokeLinecap="round">
-            <path d="M2 5l5 4 5-4" />
+          <svg width={16} height={16} viewBox="0 0 18 18" fill="var(--mf-text-muted)">
+            <circle cx={3} cy={9} r={1.5} /><circle cx={9} cy={9} r={1.5} /><circle cx={15} cy={9} r={1.5} />
           </svg>
         </button>
       </nav>


### PR DESCRIPTION
## 概要

SideNav のユーザーピル下部アイコンをシェブロンダウンから三点ドットに変更し、PostModal の書き込みキャンバスのパディングをデザイン仕様（`mf-desktop.jsx` / `mf-primitives.jsx`）に準拠させる。

## 関連 Issue

Closes #130

## 変更点

### `src/components/ui/SideNav.tsx`

- ユーザーピル右端アイコン: シェブロンダウン（`stroke="var(--mf-text-faint)"`, 14px）→ 三点ドット（`fill="var(--mf-text-muted)"`, 16px）
  - デザイン仕様のアカウントメニューボタンに合わせた三点ドット（横並び）

### `src/components/ui/PostModal.tsx`

- 書き込みキャンバスラッパー: `padding: "16px 18px"` → `"4px 22px"`
  - 上部余白を縮小し、テキストエリアが画面上部に詰まりすぎないよう左右パディングを調整

## 動作確認

- [ ] SideNav 下部のユーザーピルに三点ドットアイコンが表示される
- [ ] アカウントメニューが引き続きクリックで開閉できる
- [ ] PostModal の書き込みエリアが左右 22px の余白で表示される
- [ ] TypeScript エラーなし（`npx tsc --noEmit` 通過済み）
