### PR TITLE
refactor(home): Writing タブのメインから On This Day セクションを削除

### DIFF
--- a/src/components/home/HomeClient.tsx
+++ b/src/components/home/HomeClient.tsx
@@ -1,15 +1,12 @@
 "use client";
 
-import { useState, useMemo } from "react";
+import { useState } from "react";
 import { faceRepository } from "@/repositories/face-repository";
-import { activityRepository } from "@/repositories/activity-repository";
 import { userRepository } from "@/repositories/user-repository";
 import FaceFilterBar from "./FaceFilterBar";
 import ActivityFeed from "./ActivityFeed";
 import PostModal from "@/components/ui/PostModal";
 import FaceBadge from "@/components/ui/FaceBadge";
-import FaceChip from "@/components/ui/FaceChip";
-import { getFaceTitle } from "@/lib/display";
 
 const REFERENCE_DATE = new Date("2026-04-01");
 
@@ -19,19 +16,6 @@ const HomeClient = () => {
 
   const user = userRepository.getCurrentUser();
   const faces = faceRepository.listByUserId(user.id);
-
-  // On This Day: 同じ月日の過去のアクティビティを取得
-  const onThisDayActivities = useMemo(() => {
-    const mmdd = REFERENCE_DATE.toISOString().slice(5, 10); // "04-01"
-    const allUserActivities = activityRepository.listByUserId(user.id);
-    return allUserActivities
-      .filter((a) => {
-        const actDate = a.createdAt.slice(0, 10);
-        return actDate.slice(5) === mmdd && !actDate.startsWith("2026");
-      })
-      .slice(0, 1);
-  }, [user.id]);
-
   const defaultFace = faces[0] ?? null;
 
   const today = REFERENCE_DATE;
@@ -101,86 +85,6 @@ const HomeClient = () => {
           </span>
         </button>
       </div>
-
-      {/* On This Day */}
-      {onThisDayActivities.length > 0 && (() => {
-        const act = onThisDayActivities[0];
-        const face = faceRepository.findById(act.faceId);
-        const year = parseInt(act.createdAt.slice(0, 4), 10);
-        const yearsAgo = REFERENCE_DATE.getFullYear() - year;
-        const mmdd = act.createdAt.slice(5, 10).replace("-", "/");
-        return (
-          <div style={{ padding: "22px 18px 6px" }}>
-            {/* ヘッダー: アクセントライン + ON THIS DAY + N年前の今日 */}
-            <div
-              style={{
-                display: "flex",
-                alignItems: "center",
-                gap: 6,
-                marginBottom: 10,
-                whiteSpace: "nowrap",
-              }}
-            >
-              <div style={{ width: 14, height: 1, background: "var(--mf-accent)", flexShrink: 0 }} />
-              <span
-                style={{
-                  fontSize: 11,
-                  fontWeight: 700,
-                  color: "var(--mf-accent)",
-                  letterSpacing: 1,
-                  textTransform: "uppercase",
-                }}
-              >
-                On This Day
-              </span>
-              <span style={{ fontSize: 11.5, color: "var(--mf-text-muted)" }}>
-                · {yearsAgo}年前の今日
-              </span>
-            </div>
-            {/* カード */}
-            <div
-              style={{
-                background: "var(--mf-surface-card)",
-                borderRadius: 16,
-                padding: "14px 16px",
-                border: "0.5px solid var(--mf-line-soft)",
-              }}
-            >
-              <div style={{ display: "flex", alignItems: "center", gap: 8, marginBottom: 8 }}>
-                {face && <FaceChip faceId={face.id} title={getFaceTitle(face)} />}
-                <span style={{ fontSize: 11, color: "var(--mf-text-muted)" }}>
-                  {act.createdAt.slice(0, 4)}.{mmdd}
-                </span>
-              </div>
-              <p
-                style={{
-                  fontSize: 13.5,
-                  lineHeight: 1.7,
-                  color: "var(--mf-ink)",
-                  margin: 0,
-                  overflow: "hidden",
-                  display: "-webkit-box",
-                  WebkitLineClamp: 3,
-                  WebkitBoxOrient: "vertical",
-                }}
-              >
-                {act.body}
-              </p>
-              <p
-                style={{
-                  marginTop: 8,
-                  fontSize: 11,
-                  color: "var(--mf-text-muted)",
-                  fontStyle: "italic",
-                  margin: "8px 0 0",
-                }}
-              >
-                今のあなたは、何と返しますか
-              </p>
-            </div>
-          </div>
-        );
-      })()}
 
       {/* 最近のシード セクションヘッダー */}
       <div


### PR DESCRIPTION
## 概要

Writing タブ（`/`）のメインコンテンツに表示されていた「On This Day」セクションを削除する。同等の情報は PC 版の右側 ContextRail（WritingRail）ですでに表示されており、重複のため除去する。

## 関連 Issue

Closes #138

## 変更点

### `src/components/home/HomeClient.tsx`

- `onThisDayActivities` の `useMemo` ロジックを削除（同月日の過去アクティビティ取得処理）
- On This Day セクション UI（ヘッダー行 + カード）を削除
- 不要になった import を除去:
  - `useMemo`（`useState` のみに変更）
  - `activityRepository`
  - `FaceChip`
  - `getFaceTitle`

## 動作確認

- [ ] Writing タブのメインに On This Day セクションが表示されないこと
- [ ] WritingRail（PC版右カラム）には引き続き On This Day が表示されること
- [ ] TypeScript エラーなし（`npx tsc --noEmit` 通過済み）
