### PR TITLE
refactor(ui): PC版でシードタップによる ContextRail 詳細表示を廃止

### DIFF
--- a/src/components/face/FaceActivityFeed.tsx
+++ b/src/components/face/FaceActivityFeed.tsx
@@ -2,7 +2,6 @@
 
 import { type Face } from "@/types/face";
 import { activityRepository } from "@/repositories/activity-repository";
-import { useDetailPanel } from "@/lib/detail-panel-context";
 import SeedRow from "@/components/ui/SeedRow";
 import type { SortOrder } from "./FaceHeader";
 
@@ -12,7 +11,6 @@ type FaceActivityFeedProps = {
 };
 
 const FaceActivityFeed = ({ face, sortOrder = "newest" }: FaceActivityFeedProps) => {
-  const { openActivity } = useDetailPanel();
 
   let faceActivities = activityRepository.listByFaceId(face.id);
 
@@ -45,7 +43,6 @@ const FaceActivityFeed = ({ face, sortOrder = "newest" }: FaceActivityFeedProps)
           key={activity.id}
           activity={activity}
           face={face}
-          onClick={() => openActivity(activity.id)}
           noBorder={i === faceActivities.length - 1}
         />
       ))}

--- a/src/components/home/ActivityFeed.tsx
+++ b/src/components/home/ActivityFeed.tsx
@@ -3,7 +3,6 @@
 import { activityRepository } from "@/repositories/activity-repository";
 import { faceRepository } from "@/repositories/face-repository";
 import { userRepository } from "@/repositories/user-repository";
-import { useDetailPanel } from "@/lib/detail-panel-context";
 import { createLookupMap } from "@/lib/display";
 import SeedRow from "@/components/ui/SeedRow";
 
@@ -12,7 +11,6 @@ type ActivityFeedProps = {
 };
 
 const ActivityFeed = ({ selectedFaceId }: ActivityFeedProps) => {
-  const { openActivity } = useDetailPanel();
   const user = userRepository.getCurrentUser();
 
   const allActivities = activityRepository.listByUserId(user.id);
@@ -53,7 +51,6 @@ const ActivityFeed = ({ selectedFaceId }: ActivityFeedProps) => {
             key={activity.id}
             activity={activity}
             face={face}
-            onClick={() => openActivity(activity.id)}
             noBorder={index === displayActivities.length - 1}
           />
         );

--- a/src/components/notifications/NotificationList.tsx
+++ b/src/components/notifications/NotificationList.tsx
@@ -8,7 +8,6 @@ import { activityRepository } from "@/repositories/activity-repository";
 import { type Notification } from "@/types/notification";
 import { formatRelativeTime } from "@/lib/format-relative-time";
 import { createLookupMap, getFaceTitle, getFaceColor } from "@/lib/display";
-import { useDetailPanel } from "@/lib/detail-panel-context";
 import FaceBadge from "@/components/ui/FaceBadge";
 import DateBar from "@/components/ui/DateBar";
 
@@ -33,12 +32,8 @@ type NotifItemProps = {
 };
 
 const NotifItem = ({ notification, faceName, faceId, handle, preview, activityId }: NotifItemProps) => {
-  const { openActivity, state } = useDetailPanel();
   const isUnread = notification.createdAt >= UNREAD_CUTOFF;
   const isLink = notification.type === "link";
-
-  const isSelected =
-    state.type === "activity" && activityId !== undefined && state.activityId === activityId;
 
   const typeMeta = isLink
     ? { label: "リンク", bg: "rgba(30,42,74,0.10)", color: "var(--mf-brand)" }
@@ -50,23 +45,14 @@ const NotifItem = ({ notification, faceName, faceId, handle, preview, activityId
 
   return (
     <div
-      onClick={() => { if (activityId) openActivity(activityId); }}
-      role={activityId ? "button" : undefined}
-      tabIndex={activityId ? 0 : undefined}
-      onKeyDown={activityId ? (e) => { if (e.key === "Enter") openActivity(activityId!); } : undefined}
       style={{
         padding: "12px 18px",
-        background: isSelected
-          ? "rgba(30,42,74,0.06)"
-          : isUnread
-          ? "rgba(212,146,42,0.05)"
-          : "transparent",
+        background: isUnread ? "rgba(212,146,42,0.05)" : "transparent",
         borderBottom: "0.5px solid var(--mf-line-soft)",
         display: "flex",
         gap: 12,
         alignItems: "flex-start",
         position: "relative",
-        cursor: activityId ? "pointer" : "default",
       }}
     >
       {/* 未読ドット */}

--- a/src/components/search/SearchResults.tsx
+++ b/src/components/search/SearchResults.tsx
@@ -6,7 +6,6 @@ import { type Face } from "@/types/face";
 import SeedRow from "@/components/ui/SeedRow";
 import FaceBadge from "@/components/ui/FaceBadge";
 import { getFaceTitle } from "@/lib/display";
-import { useDetailPanel } from "@/lib/detail-panel-context";
 
 export type SearchActivityResultItem = {
   activity: Activity;
@@ -27,8 +26,6 @@ const SearchResults = ({
   faceResults,
   subscribedFaceIds,
 }: SearchResultsProps) => {
-  const { state, openActivity, openFace } = useDetailPanel();
-
   if (!query) {
     return (
       <div
@@ -97,15 +94,9 @@ const SearchResults = ({
           <ul style={{ display: "flex", flexDirection: "column", gap: 6, listStyle: "none", padding: 0, margin: 0 }}>
             {faceResults.map((face) => {
               const isSubscribed = subscribedFaceIds.includes(face.id);
-              const isSelected = state.type === "face" && state.faceId === face.id;
               return (
                 <li
                   key={face.id}
-                  onClick={() => {
-                    if (typeof window !== "undefined" && window.innerWidth >= 768) {
-                      openFace(face.id);
-                    }
-                  }}
                   style={{
                     display: "flex",
                     alignItems: "center",
@@ -113,12 +104,8 @@ const SearchResults = ({
                     gap: 12,
                     padding: "12px 14px",
                     borderRadius: 12,
-                    background: isSelected
-                      ? "rgba(30,42,74,0.06)"
-                      : "var(--mf-surface-card)",
-                    border: `0.5px solid ${isSelected ? "var(--mf-brand)" : "var(--mf-line)"}`,
-                    cursor: "pointer",
-                    transition: "background 0.15s",
+                    background: "var(--mf-surface-card)",
+                    border: "0.5px solid var(--mf-line)",
                   }}
                 >
                   <div style={{ display: "flex", alignItems: "center", gap: 10, minWidth: 0 }}>
@@ -205,7 +192,6 @@ const SearchResults = ({
                 key={activity.id}
                 activity={activity}
                 face={face}
-                onClick={() => openActivity(activity.id)}
                 noBorder={i === activityResults.length - 1}
               />
             ))}

--- a/src/components/subscriptions/SubscriptionFeed.tsx
+++ b/src/components/subscriptions/SubscriptionFeed.tsx
@@ -9,13 +9,11 @@ import { subscriptionRepository } from "@/repositories/subscription-repository";
 import SeedRow from "@/components/ui/SeedRow";
 import DateBar from "@/components/ui/DateBar";
 import FaceBadge from "@/components/ui/FaceBadge";
-import { useDetailPanel } from "@/lib/detail-panel-context";
 import { createLookupMap, getFaceTitle } from "@/lib/display";
 
 type Tab = "timeline" | "subscriptions";
 
 const SubscriptionFeed = () => {
-  const { openActivity } = useDetailPanel();
   const [activeTab, setActiveTab] = useState<Tab>("timeline");
 
   const subscribedFaceIds = subscriptionRepository.getSubscribedFaceIds();
@@ -199,7 +197,6 @@ const SubscriptionFeed = () => {
                         activity={activity}
                         face={face}
                         handle={owner?.handle}
-                        onClick={() => openActivity(activity.id)}
                         noBorder={i === acts.length - 1}
                       />
                     );

--- a/src/components/ui/ContextRail.tsx
+++ b/src/components/ui/ContextRail.tsx
@@ -2,16 +2,13 @@
 
 import Link from "next/link";
 import { usePathname } from "next/navigation";
-import { useDetailPanel } from "@/lib/detail-panel-context";
 import { activityRepository } from "@/repositories/activity-repository";
 import { faceRepository } from "@/repositories/face-repository";
 import { userRepository } from "@/repositories/user-repository";
 import { subscriptionRepository } from "@/repositories/subscription-repository";
-import { getFaceTitle, getFaceColor, getFaceKanji } from "@/lib/display";
+import { getFaceTitle, getFaceColor } from "@/lib/display";
 import { formatRelativeTime } from "@/lib/format-relative-time";
 import type { Face } from "@/types/face";
-import ActivityDetail from "./ActivityDetail";
-import FaceDetail from "./FaceDetail";
 import FaceBadge from "./FaceBadge";
 import FaceChip from "./FaceChip";
 import RailCard from "./RailCard";
@@ -336,24 +333,8 @@ const CollectionRail = () => {
 // ── ContextRail（メイン） ───────────────────────────────────────
 const ContextRail = () => {
   const pathname = usePathname();
-  const { state } = useDetailPanel();
-
-  const hasDetail = state.type === "activity" || state.type === "face";
-
-  const contentKey = hasDetail
-    ? state.type === "activity"
-      ? `activity-${state.activityId}`
-      : `face-${state.faceId}`
-    : `page-${pathname}`;
 
   const renderContent = () => {
-    if (state.type === "activity") {
-      return <ActivityDetail activityId={state.activityId} />;
-    }
-    if (state.type === "face") {
-      return <FaceDetail faceId={state.faceId} />;
-    }
-
     if (pathname === "/faces" || pathname.startsWith("/faces/")) {
       return <ReflectionRail />;
     }
@@ -368,10 +349,10 @@ const ContextRail = () => {
       className="hidden lg:flex flex-col shrink-0 overflow-y-auto mf-scroll"
       style={{
         width: 340,
-        padding: hasDetail ? 0 : "24px 20px 24px 0",
+        padding: "24px 20px 24px 0",
       }}
     >
-      <div key={contentKey} style={{ flex: 1 }}>
+      <div key={`page-${pathname}`} style={{ flex: 1 }}>
         {renderContent()}
       </div>
     </aside>

--- a/src/components/ui/SideNav.tsx
+++ b/src/components/ui/SideNav.tsx
@@ -13,7 +13,6 @@ import { faceRepository } from "@/repositories/face-repository";
 import { userRepository } from "@/repositories/user-repository";
 import { notificationRepository } from "@/repositories/notification-repository";
 import { subscriptionRepository } from "@/repositories/subscription-repository";
-import { useDetailPanel } from "@/lib/detail-panel-context";
 import type { Face } from "@/types/face";
 
 type NavItem = {
@@ -70,7 +69,6 @@ const SideNav = () => {
 
   const currentUser = userRepository.getCurrentUser();
   const faces = faceRepository.listByUserId(currentUser.id);
-  const { openFace } = useDetailPanel();
 
   const unreadNotifCount = notificationRepository.listAll().filter(
     (n) => n.createdAt >= UNREAD_CUTOFF
@@ -90,7 +88,6 @@ const SideNav = () => {
 
   const handleFaceNavItemClick = (face: Face) => {
     router.push(`/faces/${face.id}`);
-    openFace(face.id);
   };
 
   return (


### PR DESCRIPTION
## 概要

PC版でシードをタップすると ContextRail が `ActivityDetail` / `FaceDetail` に切り替わる機能を廃止する。ContextRail は各タブ固有の情報（WritingRail / ReflectionRail / CollectionRail）を常時表示するセクションとして位置づけ、シードタップによる切り替えは行わない。

## 関連 Issue

Closes #137

## 変更点

### `src/components/ui/ContextRail.tsx`

- `useDetailPanel` / `ActivityDetail` / `FaceDetail` のインポートを削除
- `hasDetail` による分岐ロジックを除去
- `contentKey` を常に `page-${pathname}` に固定
- padding を常に `"24px 20px 24px 0"` に統一
- `renderContent` からの `ActivityDetail` / `FaceDetail` 返却分岐を削除

### `src/components/home/ActivityFeed.tsx`

- `useDetailPanel` のインポートと `openActivity` 呼び出しを削除
- `SeedRow` の `onClick` prop を除去

### `src/components/face/FaceActivityFeed.tsx`

- `useDetailPanel` のインポートと `openActivity` 呼び出しを削除
- `SeedRow` の `onClick` prop を除去

### `src/components/subscriptions/SubscriptionFeed.tsx`

- `useDetailPanel` のインポートと `openActivity` 呼び出しを削除
- `SeedRow` の `onClick` prop を除去

### `src/components/notifications/NotificationList.tsx`

- `useDetailPanel` のインポートを削除
- `openActivity` / `state` / `isSelected` の参照を除去
- 通知アイテムのクリック・キーボードハンドラを削除
- `isSelected` によるハイライト背景を除去

### `src/components/search/SearchResults.tsx`

- `useDetailPanel` のインポートと `state` / `openActivity` / `openFace` の呼び出しを削除
- フェイス検索結果の `isSelected` ハイライトと `onClick` ハンドラを除去
- シード検索結果の `SeedRow` から `onClick` prop を除去

### `src/components/ui/SideNav.tsx`

- `useDetailPanel` のインポートと `openFace` 呼び出しを削除
- `handleFaceNavItemClick` を `router.push` のみに簡略化

## 備考

- `ActivityDetail.tsx` / `FaceDetail.tsx` / `detail-panel-context.tsx` は将来の Issue #117（シード詳細スタンドアロンページ）で再利用する可能性があるため、ファイル自体は残す

## 動作確認

- [ ] Writing / Reflection / Collection / 通知 / 検索の各タブでシードをタップしても ContextRail が切り替わらないこと
- [ ] ContextRail が常にタブ固有のレール（WritingRail / ReflectionRail / CollectionRail）を表示すること
- [ ] SideNav のマイフェイスクリックで `/faces/:id` にページ遷移できること
- [ ] TypeScript エラーなし（`npx tsc --noEmit` 通過済み）
