### PR TITLE
fix(ui): ContextRail WritingRail 検索カード削除・CollectionRail ボタン色統一

### DIFF
--- a/src/components/ui/ContextRail.tsx
+++ b/src/components/ui/ContextRail.tsx
@@ -119,17 +119,6 @@ const WritingRail = () => {
         </div>
       </RailCard>
 
-      <RailCard pad="14px">
-        <div style={{ display: "flex", alignItems: "center", gap: 10, color: "var(--mf-text-muted)", fontSize: 13 }}>
-          <svg width={18} height={18} viewBox="0 0 18 18" fill="none" stroke="currentColor" strokeWidth={1.6} strokeLinecap="round" strokeLinejoin="round">
-            <circle cx={8} cy={8} r={5.5} /><path d="M12.2 12.2L16 16" />
-          </svg>
-          すべてを検索
-          <div style={{ marginLeft: "auto", fontSize: 10.5, padding: "2px 6px", background: "var(--mf-surface-tint)", borderRadius: 4, color: "var(--mf-text-sub)", fontWeight: 700 }}>
-            ⌘K
-          </div>
-        </div>
-      </RailCard>
     </div>
   );
 };

--- a/src/components/ui/ContextRail.tsx
+++ b/src/components/ui/ContextRail.tsx
@@ -299,9 +299,9 @@ const CollectionRail = () => {
                 style={{
                   padding: "5px 10px",
                   borderRadius: 999,
-                  background: i === 0 ? "var(--mf-brand)" : "transparent",
-                  border: i === 0 ? "none" : "1px solid var(--mf-brand)",
-                  color: i === 0 ? "#fff" : "var(--mf-brand)",
+                  background: "transparent",
+                  border: "1px solid var(--mf-brand)",
+                  color: "var(--mf-brand)",
                   fontSize: 11,
                   fontWeight: 700,
                   cursor: "pointer",


### PR DESCRIPTION
## 概要

ContextRail の WritingRail と CollectionRail に存在していた2つのスタイル上の問題を修正する。WritingRail の「すべてを検索」カードはページコンテンツと重複するため削除し、CollectionRail のおすすめセクションでは先頭ボタンだけ異なるカラーになっていた不統一を解消する。

Closes #145
Closes #146

## 変更点

- `src/components/ui/ContextRail.tsx`
  - `WritingRail` 内の「すべてを検索」`RailCard`（⌘K バッジ付き）を削除
  - `CollectionRail` おすすめセクションのサブスクボタンスタイルを統一（`i === 0` の分岐を除去し、全ボタンを `transparent` 背景・`var(--mf-brand)` ボーダー・テキストに統一）

## 動作確認

- [ ] Writing タブのコンテキストレイルに「すべてを検索」カードが表示されないこと
- [ ] Collection タブのコンテキストレイル「おすすめ」セクションの全ボタンが同じスタイルで表示されること
- [ ] その他のRailCard（On This Day、今月の記録、サブスク中）に影響がないこと
