### PR TITLE
fix(ui): Collection タブタイトルを「収集」に変更・検索バーをタイトル下に追加

### DIFF
--- a/src/components/subscriptions/SubscriptionFeed.tsx
+++ b/src/components/subscriptions/SubscriptionFeed.tsx
@@ -56,25 +56,36 @@ const SubscriptionFeed = () => {
     <div>
       {/* ページタイトル */}
       <div style={{ padding: "4px 18px 14px" }}>
-        <div style={{ display: "flex", alignItems: "baseline", justifyContent: "space-between" }}>
-          <div
-            style={{
-              fontSize: 22,
-              fontWeight: 700,
-              color: "var(--mf-brand)",
-              letterSpacing: -0.3,
-              fontFamily: "var(--mf-font-sans)",
-            }}
-          >
-            蒐集
+        <div
+          style={{
+            fontSize: 22,
+            fontWeight: 700,
+            color: "var(--mf-brand)",
+            letterSpacing: -0.3,
+            fontFamily: "var(--mf-font-sans)",
+            marginBottom: 12,
+          }}
+        >
+          収集
+        </div>
+        {/* 検索バー */}
+        <div
+          style={{
+            display: "flex",
+            alignItems: "center",
+            gap: 10,
+            padding: "10px 14px",
+            background: "var(--mf-surface)",
+            borderRadius: 12,
+            border: "0.5px solid var(--mf-line)",
+          }}
+        >
+          <svg width={16} height={16} viewBox="0 0 18 18" fill="none" stroke="var(--mf-text-muted)" strokeWidth={1.6} strokeLinecap="round" strokeLinejoin="round">
+            <circle cx={8} cy={8} r={5.5} /><path d="M12.2 12.2L16 16" />
+          </svg>
+          <div style={{ flex: 1, color: "var(--mf-text-muted)", fontSize: 13, fontFamily: "var(--mf-font-sans)" }}>
+            フェイス・シードを検索
           </div>
-          {subscribedFaces.length === 0 ? (
-            <div style={{ fontSize: 12, color: "var(--mf-text-sub)" }}>気になるフェイスを見つける</div>
-          ) : (
-            <svg width={18} height={18} viewBox="0 0 18 18" fill="none" stroke="var(--mf-brand)" strokeWidth={1.6} strokeLinecap="round" strokeLinejoin="round">
-              <circle cx={8} cy={8} r={5.5} /><path d="M12.2 12.2L16 16" />
-            </svg>
-          )}
         </div>
       </div>
 


### PR DESCRIPTION
## 概要

Collection タブのページタイトル周辺 UI を改修する。誤字「蒐集」を正しい「収集」に修正し、タイトル行右端の検索アイコンを廃止して、タイトル直下に常時表示の検索バーを新設する。

Closes #144

## 変更点

- `src/components/subscriptions/SubscriptionFeed.tsx`
  - ページタイトルを「蒐集」→「収集」に修正
  - タイトル行の `justify-content: space-between` レイアウトを廃止し、タイトルを単独ブロックに変更
  - サブスク有無による条件分岐（検索アイコン / 「気になるフェイスを見つける」テキスト）を削除
  - タイトル直下に検索バーを常時表示（`var(--mf-surface)` 背景・`border-radius: 12px`）

## 動作確認

- [ ] Collection タブのページタイトルが「収集」と表示されること
- [ ] タイトル行右端に検索アイコンが表示されないこと
- [ ] タイトルの下に検索バーが常時表示されること（サブスク有無に関わらず）
- [ ] タブ（タイムライン / サブスク一覧）の表示に影響がないこと
