### PR TITLE
feat(home): Writing タブのモバイル版に On This Day セクションを lg:hidden で復元

### DIFF
--- a/src/components/home/HomeClient.tsx
+++ b/src/components/home/HomeClient.tsx
@@ -1,12 +1,15 @@
 "use client";
 
-import { useState } from "react";
+import { useState, useMemo } from "react";
 import { faceRepository } from "@/repositories/face-repository";
 import { userRepository } from "@/repositories/user-repository";
+import { activityRepository } from "@/repositories/activity-repository";
+import { getFaceTitle } from "@/lib/display";
 import FaceFilterBar from "./FaceFilterBar";
 import ActivityFeed from "./ActivityFeed";
 import PostModal from "@/components/ui/PostModal";
 import FaceBadge from "@/components/ui/FaceBadge";
+import FaceChip from "@/components/ui/FaceChip";
 
 const REFERENCE_DATE = new Date("2026-04-01");
 
@@ -19,6 +22,21 @@ const HomeClient = () => {
   const defaultFace = faces[0] ?? null;
 
   const today = REFERENCE_DATE;
+
+  const allActivities = activityRepository.listByUserId(user.id);
+  const mmdd = REFERENCE_DATE.toISOString().slice(5, 10);
+  const onThisDay = useMemo(
+    () =>
+      allActivities.find((a) => {
+        const d = a.createdAt.slice(0, 10);
+        return d.slice(5) === mmdd && !d.startsWith("2026");
+      }),
+    [allActivities, mmdd]
+  );
+  const onThisDayFace = onThisDay ? faceRepository.findById(onThisDay.faceId) : undefined;
+  const yearsAgo = onThisDay
+    ? REFERENCE_DATE.getFullYear() - parseInt(onThisDay.createdAt.slice(0, 4), 10)
+    : 0;
   const weekday = ["日", "月", "火", "水", "木", "金", "土"][today.getDay()];
   const dateLabel = `${today.getMonth() + 1}月${today.getDate()}日 (${weekday})`;
 
@@ -85,6 +103,50 @@ const HomeClient = () => {
           </span>
         </button>
       </div>
+
+      {/* On This Day — PC は ContextRail が担当するため lg:hidden */}
+      {onThisDay && onThisDayFace && (
+        <div className="lg:hidden" style={{ padding: "14px 18px 0" }}>
+          <div
+            style={{
+              padding: "14px 16px",
+              borderRadius: 14,
+              background: "var(--mf-surface)",
+              border: "0.5px solid var(--mf-line)",
+            }}
+          >
+            <div style={{ display: "flex", alignItems: "center", justifyContent: "space-between", marginBottom: 10 }}>
+              <span style={{ fontSize: 11, fontWeight: 700, color: "var(--mf-text-muted)", letterSpacing: 0.6, textTransform: "uppercase" }}>
+                On This Day
+              </span>
+              <span style={{ fontSize: 11, color: "var(--mf-text-muted)" }}>{yearsAgo}年前</span>
+            </div>
+            <div style={{ display: "flex", alignItems: "center", gap: 6, marginBottom: 8 }}>
+              <FaceChip faceId={onThisDayFace.id} title={getFaceTitle(onThisDayFace)} />
+              <span style={{ fontSize: 10.5, color: "var(--mf-text-muted)" }}>
+                {onThisDay.createdAt.slice(0, 10).replace(/-/g, ".")}
+              </span>
+            </div>
+            <p
+              style={{
+                fontSize: 13,
+                lineHeight: 1.65,
+                color: "var(--mf-ink)",
+                margin: 0,
+                overflow: "hidden",
+                display: "-webkit-box",
+                WebkitLineClamp: 2,
+                WebkitBoxOrient: "vertical",
+              }}
+            >
+              {onThisDay.body}
+            </p>
+            <p style={{ marginTop: 8, fontSize: 11, color: "var(--mf-text-muted)", fontStyle: "italic", margin: "8px 0 0" }}>
+              今のあなたは、何と返しますか
+            </p>
+          </div>
+        </div>
+      )}
 
       {/* 最近のシード セクションヘッダー */}
       <div


### PR DESCRIPTION
## 概要

PR #139 で Writing タブのメインコンテンツから On This Day セクションを削除したことにより、ContextRail が非表示になるモバイル幅（<1024px）で On This Day が一切確認できない状態になっていた。PC では ContextRail（WritingRail）が On This Day を表示するため重複を避けつつ、モバイルでも閲覧できるよう `lg:hidden` で制御して HomeClient に復元する。

Closes #142

## 変更点

- `src/components/home/HomeClient.tsx`
  - `useMemo`・`activityRepository`・`getFaceTitle`・`FaceChip` を import 追加
  - `allActivities` の取得と `onThisDay` / `onThisDayFace` / `yearsAgo` の算出ロジックを追加
  - コンポーズボックスと「最近のシード」ヘッダーの間に On This Day カードを `<div className="lg:hidden">` で囲んで追加
  - PC（≥1024px）では非表示、モバイル（<1024px）では表示される設計

## 動作確認

- [ ] モバイル幅（<1024px）で On This Day セクションが表示されること
- [ ] PC 幅（≥1024px）で On This Day セクションが非表示になること（ContextRail に表示）
- [ ] On This Day データが存在しない場合はセクション自体が非表示になること
- [ ] 「最近のシード」セクションの表示に影響がないこと
