### PR TITLE
feat(ui): モバイル版コンポーズバーをボトムナビ上に常時表示

### DIFF
--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -1,6 +1,7 @@
 import type { Metadata } from "next";
 import "./globals.css";
 import BottomNav from "@/components/ui/BottomNav";
+import MobileComposeBar from "@/components/ui/MobileComposeBar";
 import SideNav from "@/components/ui/SideNav";
 import AppHeader from "@/components/ui/AppHeader";
 import ContextRail from "@/components/ui/ContextRail";
@@ -34,7 +35,7 @@ export default function RootLayout({
               <AppHeader />
               <div className="flex flex-1 min-h-0 overflow-hidden">
                 <main
-                  className="flex-1 min-w-0 overflow-y-auto pb-16 md:pb-0"
+                  className="flex-1 min-w-0 overflow-y-auto pb-36 md:pb-0"
                   style={{ borderRight: "0.5px solid var(--mf-line)" }}
                 >
                   {children}
@@ -43,6 +44,7 @@ export default function RootLayout({
               </div>
             </div>
           </div>
+          <MobileComposeBar />
           <BottomNav />
         </DetailPanelProvider>
       </body>

--- a/src/components/home/HomeClient.tsx
+++ b/src/components/home/HomeClient.tsx
@@ -7,19 +7,15 @@ import { activityRepository } from "@/repositories/activity-repository";
 import { getFaceTitle } from "@/lib/display";
 import FaceFilterBar from "./FaceFilterBar";
 import ActivityFeed from "./ActivityFeed";
-import PostModal from "@/components/ui/PostModal";
-import FaceBadge from "@/components/ui/FaceBadge";
 import FaceChip from "@/components/ui/FaceChip";
 
 const REFERENCE_DATE = new Date("2026-04-01");
 
 const HomeClient = () => {
   const [selectedFaceId, setSelectedFaceId] = useState<string | null>(null);
-  const [isModalOpen, setIsModalOpen] = useState(false);
 
   const user = userRepository.getCurrentUser();
   const faces = faceRepository.listByUserId(user.id);
-  const defaultFace = faces[0] ?? null;
 
   const today = REFERENCE_DATE;
 
@@ -55,53 +51,6 @@ const HomeClient = () => {
             {dateLabel}
           </div>
         </div>
-      </div>
-
-      {/* インラインコンポーズ */}
-      <div style={{ padding: "0 18px" }}>
-        <button
-          type="button"
-          onClick={() => setIsModalOpen(true)}
-          style={{
-            width: "100%",
-            display: "flex",
-            alignItems: "center",
-            gap: 10,
-            padding: "10px 14px",
-            borderRadius: 16,
-            background: "var(--mf-surface)",
-            border: "0.5px solid var(--mf-line)",
-            cursor: "pointer",
-            textAlign: "left",
-          }}
-        >
-          {defaultFace && (
-            <FaceBadge face={defaultFace} size={32} radius={9} />
-          )}
-          <span
-            style={{
-              flex: 1,
-              fontSize: 14,
-              color: "var(--mf-text-faint)",
-              fontFamily: "var(--mf-font-sans)",
-            }}
-          >
-            今、何を書く？
-          </span>
-          <span
-            style={{
-              padding: "5px 14px",
-              borderRadius: 999,
-              background: "var(--mf-accent)",
-              color: "#fff",
-              fontSize: 12,
-              fontWeight: 700,
-              flexShrink: 0,
-            }}
-          >
-            投稿
-          </span>
-        </button>
       </div>
 
       {/* On This Day — PC は ContextRail が担当するため lg:hidden */}
@@ -186,10 +135,6 @@ const HomeClient = () => {
         <ActivityFeed selectedFaceId={selectedFaceId} />
       </div>
 
-      <PostModal
-        isOpen={isModalOpen}
-        onClose={() => setIsModalOpen(false)}
-      />
     </div>
   );
 };

--- a/src/components/ui/MobileComposeBar.tsx
+++ b/src/components/ui/MobileComposeBar.tsx
@@ -1,0 +1,82 @@
+"use client";
+
+import { useState } from "react";
+import { faceRepository } from "@/repositories/face-repository";
+import { userRepository } from "@/repositories/user-repository";
+import PostModal from "@/components/ui/PostModal";
+import FaceBadge from "@/components/ui/FaceBadge";
+
+const MobileComposeBar = () => {
+  const [isModalOpen, setIsModalOpen] = useState(false);
+
+  const user = userRepository.getCurrentUser();
+  const faces = faceRepository.listByUserId(user.id);
+  const defaultFace = faces[0] ?? null;
+
+  return (
+    <>
+      <div
+        className="md:hidden fixed left-0 right-0 z-40"
+        style={{
+          bottom: 73,
+          padding: "8px 14px",
+          background: "rgba(248,246,241,0.92)",
+          backdropFilter: "blur(20px) saturate(180%)",
+          WebkitBackdropFilter: "blur(20px) saturate(180%)",
+          borderTop: "0.5px solid var(--mf-line)",
+        }}
+      >
+        <button
+          type="button"
+          onClick={() => setIsModalOpen(true)}
+          style={{
+            width: "100%",
+            display: "flex",
+            alignItems: "center",
+            gap: 10,
+            padding: "9px 14px",
+            borderRadius: 14,
+            background: "var(--mf-surface)",
+            border: "0.5px solid var(--mf-line)",
+            cursor: "pointer",
+            textAlign: "left",
+          }}
+        >
+          {defaultFace && (
+            <FaceBadge face={defaultFace} size={30} radius={8} />
+          )}
+          <span
+            style={{
+              flex: 1,
+              fontSize: 14,
+              color: "var(--mf-text-faint)",
+              fontFamily: "var(--mf-font-sans)",
+            }}
+          >
+            今、何を書く？
+          </span>
+          <span
+            style={{
+              padding: "5px 14px",
+              borderRadius: 999,
+              background: "var(--mf-accent)",
+              color: "#fff",
+              fontSize: 12,
+              fontWeight: 700,
+              flexShrink: 0,
+            }}
+          >
+            投稿
+          </span>
+        </button>
+      </div>
+
+      <PostModal
+        isOpen={isModalOpen}
+        onClose={() => setIsModalOpen(false)}
+      />
+    </>
+  );
+};
+
+export default MobileComposeBar;


### PR DESCRIPTION
## 概要

モバイル版でコンポーズ（投稿）導線が Writing タブにしか存在しなかった問題を解消する。新コンポーネント `MobileComposeBar` をボトムナビゲーションのすぐ上に `fixed` 配置し、全タブで常時表示されるようにする。合わせて `HomeClient` に存在していたインラインコンポーズボックスを削除して重複を排除する。

Closes #151

## 変更点

- `src/components/ui/MobileComposeBar.tsx`（新規作成）
  - `md:hidden fixed` で `bottom: 73px`（BottomNav 高さ相当）に配置
  - デフォルトフェイスの `FaceBadge` + 「今、何を書く？」プレースホルダー + 「投稿」ボタンを表示
  - タップで `PostModal` を開く（内部で state 管理）
  - BottomNav と同様のすりガラス背景（`backdrop-filter: blur`）

- `src/app/layout.tsx`
  - `<MobileComposeBar />` を `<BottomNav />` の直前に追加
  - メインコンテンツの `pb-16` → `pb-36` に変更（MobileComposeBar 分のスクロール余白を確保）

- `src/components/home/HomeClient.tsx`
  - インラインコンポーズボックス（`<button>今、何を書く？</button>`）を削除
  - `PostModal`・`FaceBadge` の import を削除
  - `isModalOpen` state・`defaultFace` 変数を削除

## 動作確認

- [ ] Writing / Reflection / Collection の全タブでコンポーズバーがボトムナビ上に表示されること
- [ ] コンポーズバーをタップすると PostModal が開くこと
- [ ] PC 幅（md 以上）ではコンポーズバーが非表示になること
- [ ] Writing タブのインラインコンポーズボックスが消えていること
- [ ] コンテンツがコンポーズバーの裏に隠れずスクロールできること
