### PR TITLE
fix(data): REFERENCE_DATE を 2026-03-31 に変更してモックデータを正しく表示

### DIFF
--- a/src/components/home/HomeClient.tsx
+++ b/src/components/home/HomeClient.tsx
@@ -9,7 +9,7 @@ import FaceFilterBar from "./FaceFilterBar";
 import ActivityFeed from "./ActivityFeed";
 import FaceChip from "@/components/ui/FaceChip";
 
-const REFERENCE_DATE = new Date("2026-04-01");
+const REFERENCE_DATE = new Date("2026-03-31");
 
 const HomeClient = () => {
   const [selectedFaceId, setSelectedFaceId] = useState<string | null>(null);

--- a/src/components/ui/ContextRail.tsx
+++ b/src/components/ui/ContextRail.tsx
@@ -14,7 +14,7 @@ import FaceChip from "./FaceChip";
 import RailCard from "./RailCard";
 import SeedRow from "./SeedRow";
 
-const REFERENCE_DATE = new Date("2026-04-01");
+const REFERENCE_DATE = new Date("2026-03-31");
 
 // ── WritingRail ────────────────────────────────────────────────
 const WritingRail = () => {


### PR DESCRIPTION
## 概要

`REFERENCE_DATE` が `"2026-04-01"` に設定されていたため「今月 = 2026-04」となり、モックデータ（`src/mocks/activities.ts`）に 2026-04 のアクティビティが存在しないことで「今月の記録」「アクティビティ」セクションがすべて 0 または空表示になっていた。`"2026-03-31"` に変更することで `thisMonth = "2026-03"` となり、既存のモックデータが正しく反映される。

Closes #153
Closes #111

## 変更点

- `src/components/ui/ContextRail.tsx` — `REFERENCE_DATE` を `"2026-04-01"` → `"2026-03-31"` に変更
- `src/components/home/HomeClient.tsx` — `REFERENCE_DATE` を `"2026-04-01"` → `"2026-03-31"` に変更

## 動作確認

- [ ] WritingRail「今月の記録」でシード数・日連続・フェイス数に 0 以外の値が表示されること
- [ ] WritingRail バーチャートに 2026-03 の日別アクティビティが反映されること
- [ ] ReflectionRail「アクティビティ」にフェイス別の今月の記録が表示されること
- [ ] HomeClient の On This Day（モバイル）が 2026-03-31 基準で正しく機能すること
