### PR TITLE
fix(ui): WritingRail 今月の記録の数値フォントをサンセリフに変更

### DIFF
--- a/src/components/ui/ContextRail.tsx
+++ b/src/components/ui/ContextRail.tsx
@@ -94,7 +94,7 @@ const WritingRail = () => {
             { n: String(monthlyFaces), l: "フェイス" },
           ].map((s) => (
             <div key={s.l} style={{ textAlign: "center" }}>
-              <div style={{ fontSize: 22, fontWeight: 700, color: "var(--mf-brand)", fontFamily: "var(--mf-font-serif-en)" }}>
+              <div style={{ fontSize: 22, fontWeight: 700, color: "var(--mf-brand)", fontFamily: "var(--mf-font-sans)" }}>
                 {s.n}
               </div>
               <div style={{ fontSize: 11, color: "var(--mf-text-muted)", marginTop: 2 }}>{s.l}</div>


### PR DESCRIPTION
## 概要

WritingRail の「今月の記録」セクションに表示されるシード数・日連続・フェイス数の数値に `var(--mf-font-serif-en)`（Cormorant Garamond 等のセリフ体）が適用されており、`0` が円形に見えて数字としての視認性が低い問題を修正する。`var(--mf-font-sans)` に変更してすっきり読めるようにする。

Closes #154

## 変更点

- `src/components/ui/ContextRail.tsx`（`WritingRail` 内「今月の記録」数値表示）
  - `fontFamily: "var(--mf-font-serif-en)"` → `fontFamily: "var(--mf-font-sans)"` に変更

## 動作確認

- [ ] WritingRail「今月の記録」の数値（シード / 日連続 / フェイス）がサンセリフフォントで表示されること
- [ ] `0` が丸く見えずに数字として明確に読み取れること
- [ ] 他のスタイル（サイズ・ウェイト・カラー）に変更がないこと
