### PR TITLE
fix(data): On This Day 表示のため 2025-03-31 のモックデータを追加

### DIFF
--- a/src/mocks/activities.ts
+++ b/src/mocks/activities.ts
@@ -684,6 +684,8 @@ const face4_3Activities: Activity[] = [
 
 // ─── user-1 の 2025 年分の履歴アクティビティ（カレンダー映え用）───────────
 const face1_historicalActivities: Activity[] = [
+  // 2025年3月
+  { id: "act-h-0", faceId: "face-1-4", userId: "user-1", body: "年度末。今年度を振り返ってみると、思ったよりいろんなことがあった。来年度は少しだけ丁寧に暮らしていきたい。", createdAt: "2025-03-31T22:30:00+09:00" },
   // 2025年4月
   { id: "act-h-1", faceId: "face-1-1", userId: "user-1", body: "『火花』を読了。芸人の世界がこれほど繊細に描かれているとは思わなかった。", createdAt: "2025-04-07T21:00:00+09:00" },
   { id: "act-h-2", faceId: "face-1-4", userId: "user-1", body: "花見。近所の公園の桜がちょうど満開だった。来年もこの景色を見たい。", imageUrls: ["https://picsum.photos/seed/hanami/600/400"], createdAt: "2025-04-05T16:30:00+09:00" },


### PR DESCRIPTION
## 概要

PR #155 で `REFERENCE_DATE` を `"2026-04-01"` から `"2026-03-31"` に変更した結果、Writing タブおよびモバイルの「On This Day」セクションが非表示になる問題が発生した。

原因は、On This Day のマッチロジック（`mmdd = "03-31"` の過去アクティビティを検索）に対応するモックデータが存在しなかったこと。本PRでは2025年3月31日のアクティビティを追加することで表示を復元する。

## 関連Issue

Refs #153

## 変更点

- `src/mocks/activities.ts`
  - `face1_historicalActivities` に `act-h-0`（`2025-03-31T22:30:00+09:00`）を追加
  - `face-1-4`（今日の出来事）フェイスの年度末の記録として自然な内容で実装

## 動作確認

- [ ] Writing タブの ContextRail に「On This Day」カードが表示される
- [ ] モバイル（lg未満）の HomeClient にも「On This Day」セクションが表示される
- [ ] 表示内容が `face-1-4` のアクティビティ（`act-h-0`）と一致している
