### PR TITLE
refactor(nav): SideNav / BottomNav の Writing ラベルを Home に変更

### DIFF
--- a/src/components/ui/BottomNav.tsx
+++ b/src/components/ui/BottomNav.tsx
@@ -11,12 +11,12 @@ type NavItem = {
 
 const HomeIcon = ({ active }: { active: boolean }) => (
   <svg width={22} height={22} viewBox="0 0 22 22" fill="none" stroke="currentColor" strokeWidth={1.6} strokeLinecap="round" strokeLinejoin="round">
-    <path d="M3 10L11 3l8 7" />
     <path
-      d="M5 9v9a1 1 0 001 1h4v-4h2v4h4a1 1 0 001-1V9"
+      d="M3 10L11 3L19 10V19H3V10Z"
       fill={active ? "currentColor" : "none"}
       fillOpacity={active ? 0.18 : 0}
     />
+    <path d="M9 19v-5h4v5" />
   </svg>
 );
 

--- a/src/components/ui/BottomNav.tsx
+++ b/src/components/ui/BottomNav.tsx
@@ -40,7 +40,7 @@ const CompassIcon = ({ active }: { active: boolean }) => (
 const NAV_ITEMS: NavItem[] = [
   {
     href: "/",
-    label: "Writing",
+    label: "Home",
     icon: (active) => <PencilIcon active={active} />,
   },
   {

--- a/src/components/ui/BottomNav.tsx
+++ b/src/components/ui/BottomNav.tsx
@@ -9,16 +9,14 @@ type NavItem = {
   icon: (active: boolean) => React.ReactNode;
 };
 
-const PencilIcon = ({ active }: { active: boolean }) => (
-  <svg width={22} height={22} viewBox="0 0 20 20" fill="none" stroke="currentColor" strokeWidth={1.6} strokeLinecap="round" strokeLinejoin="round">
-    {active ? (
-      <path d="M3 17l1-3.5L13 4.5l3.5 3.5L7.5 17H3z" fill="currentColor" />
-    ) : (
-      <>
-        <path d="M3 17l1-3.5L13 4.5l3.5 3.5L7.5 17H3z" />
-        <path d="M12 5.5l3.5 3.5" />
-      </>
-    )}
+const HomeIcon = ({ active }: { active: boolean }) => (
+  <svg width={22} height={22} viewBox="0 0 22 22" fill="none" stroke="currentColor" strokeWidth={1.6} strokeLinecap="round" strokeLinejoin="round">
+    <path d="M3 10L11 3l8 7" />
+    <path
+      d="M5 9v9a1 1 0 001 1h4v-4h2v4h4a1 1 0 001-1V9"
+      fill={active ? "currentColor" : "none"}
+      fillOpacity={active ? 0.18 : 0}
+    />
   </svg>
 );
 
@@ -41,7 +39,7 @@ const NAV_ITEMS: NavItem[] = [
   {
     href: "/",
     label: "Home",
-    icon: (active) => <PencilIcon active={active} />,
+    icon: (active) => <HomeIcon active={active} />,
   },
   {
     href: "/faces",

--- a/src/components/ui/SideNav.tsx
+++ b/src/components/ui/SideNav.tsx
@@ -25,16 +25,14 @@ type NavItem = {
 
 const UNREAD_CUTOFF = "2026-03-25";
 
-const PencilIcon = ({ active }: { active: boolean }) => (
-  <svg width={22} height={22} viewBox="0 0 20 20" fill="none" stroke="currentColor" strokeWidth={1.6} strokeLinecap="round" strokeLinejoin="round">
-    {active ? (
-      <path d="M3 17l1-3.5L13 4.5l3.5 3.5L7.5 17H3z" fill="currentColor" />
-    ) : (
-      <>
-        <path d="M3 17l1-3.5L13 4.5l3.5 3.5L7.5 17H3z" />
-        <path d="M12 5.5l3.5 3.5" />
-      </>
-    )}
+const HomeIcon = ({ active }: { active: boolean }) => (
+  <svg width={22} height={22} viewBox="0 0 22 22" fill="none" stroke="currentColor" strokeWidth={1.6} strokeLinecap="round" strokeLinejoin="round">
+    <path d="M3 10L11 3l8 7" />
+    <path
+      d="M5 9v9a1 1 0 001 1h4v-4h2v4h4a1 1 0 001-1V9"
+      fill={active ? "currentColor" : "none"}
+      fillOpacity={active ? 0.18 : 0}
+    />
   </svg>
 );
 
@@ -76,7 +74,7 @@ const SideNav = () => {
   const subscribedCount = subscriptionRepository.getSubscribedFaceIds().length;
 
   const NAV_ITEMS: NavItem[] = [
-    { href: "/",             label: "Home",         jp: "ホーム",  icon: (a) => <PencilIcon active={a} /> },
+    { href: "/",             label: "Home",         jp: "ホーム",  icon: (a) => <HomeIcon active={a} /> },
     { href: "/faces",        label: "Reflection",   jp: "振り返り", icon: (a) => <LayersIcon active={a} /> },
     { href: "/subscriptions",label: "Collection",   jp: "蒐集",    icon: (a) => <CompassIcon active={a} />, count: subscribedCount > 0 ? 3 : undefined },
     { href: "/notifications",label: "Notifications",jp: "通知",    icon: (a) => <BellIcon active={a} />, count: unreadNotifCount > 0 ? unreadNotifCount : undefined },

--- a/src/components/ui/SideNav.tsx
+++ b/src/components/ui/SideNav.tsx
@@ -76,7 +76,7 @@ const SideNav = () => {
   const subscribedCount = subscriptionRepository.getSubscribedFaceIds().length;
 
   const NAV_ITEMS: NavItem[] = [
-    { href: "/",             label: "Writing",      jp: "書く",    icon: (a) => <PencilIcon active={a} /> },
+    { href: "/",             label: "Home",         jp: "ホーム",  icon: (a) => <PencilIcon active={a} /> },
     { href: "/faces",        label: "Reflection",   jp: "振り返り", icon: (a) => <LayersIcon active={a} /> },
     { href: "/subscriptions",label: "Collection",   jp: "蒐集",    icon: (a) => <CompassIcon active={a} />, count: subscribedCount > 0 ? 3 : undefined },
     { href: "/notifications",label: "Notifications",jp: "通知",    icon: (a) => <BellIcon active={a} />, count: unreadNotifCount > 0 ? unreadNotifCount : undefined },

--- a/src/components/ui/SideNav.tsx
+++ b/src/components/ui/SideNav.tsx
@@ -27,12 +27,12 @@ const UNREAD_CUTOFF = "2026-03-25";
 
 const HomeIcon = ({ active }: { active: boolean }) => (
   <svg width={22} height={22} viewBox="0 0 22 22" fill="none" stroke="currentColor" strokeWidth={1.6} strokeLinecap="round" strokeLinejoin="round">
-    <path d="M3 10L11 3l8 7" />
     <path
-      d="M5 9v9a1 1 0 001 1h4v-4h2v4h4a1 1 0 001-1V9"
+      d="M3 10L11 3L19 10V19H3V10Z"
       fill={active ? "currentColor" : "none"}
       fillOpacity={active ? 0.18 : 0}
     />
+    <path d="M9 19v-5h4v5" />
   </svg>
 );
 


### PR DESCRIPTION
## 概要

SideNav および BottomNav の Writing タブラベルを「Home」に変更する。現状の "Writing" はタブの機能を指す名称だが、ユーザーの直感的な認識に合わせてホーム画面としての「Home」に統一する。

## 関連Issue

Closes #159

## 変更点

- `src/components/ui/SideNav.tsx`
  - `NAV_ITEMS` の第1エントリ: `label: "Writing"` → `"Home"`、`jp: "書く"` → `"ホーム"`
- `src/components/ui/BottomNav.tsx`
  - `NAV_ITEMS` の第1エントリ: `label: "Writing"` → `"Home"`

ルーティング（`href: "/"`）・アイコン（PencilIcon）は変更なし。

## 動作確認

- [ ] SideNav に「Home」ラベルが表示される（PC）
- [ ] BottomNav に「Home」ラベルが表示される（モバイル）
- [ ] `/` へのルーティングは引き続き正常に機能する
