### PR TITLE
refactor(ui): 「On This Day」表示ラベルを「一年前の今日」に変更

### DIFF
--- a/src/components/home/HomeClient.tsx
+++ b/src/components/home/HomeClient.tsx
@@ -70,7 +70,7 @@ const HomeClient = () => {
           >
             <div style={{ display: "flex", alignItems: "center", justifyContent: "space-between", marginBottom: 10 }}>
               <span style={{ fontSize: 11, fontWeight: 700, color: "var(--mf-text-muted)", letterSpacing: 0.6, textTransform: "uppercase" }}>
-                On This Day
+                一年前の今日
               </span>
               <span style={{ fontSize: 11, color: "var(--mf-text-muted)" }}>{yearsAgo}年前</span>
             </div>

--- a/src/components/ui/ContextRail.tsx
+++ b/src/components/ui/ContextRail.tsx
@@ -58,7 +58,7 @@ const WritingRail = () => {
     <div style={{ display: "flex", flexDirection: "column", gap: 14 }}>
       {/* On This Day */}
       {onThisDay && onThisDayFace && (
-        <RailCard title="On This Day" action={`${yearsAgo}年前`}>
+        <RailCard title="一年前の今日" action={`${yearsAgo}年前`}>
           <div style={{ display: "flex", alignItems: "center", gap: 6, marginBottom: 8 }}>
             <FaceChip faceId={onThisDayFace.id} title={getFaceTitle(onThisDayFace)} />
             <span style={{ fontSize: 10.5, color: "var(--mf-text-muted)" }}>


### PR DESCRIPTION
## 概要

Home タブおよびモバイル版で「On This Day」と英語表記されていたラベルを「一年前の今日」に変更する。日本語ユーザーにとって直感的でなく、コンテンツの意味が伝わりにくかったため修正した。

## 関連Issue

Closes #162

## 変更点

- `src/components/ui/ContextRail.tsx` — `WritingRail` 内 `RailCard title="On This Day"` → `"一年前の今日"`
- `src/components/home/HomeClient.tsx` — モバイル版ラベルテキスト `"On This Day"` → `"一年前の今日"`

`${yearsAgo}年前` のサブラベル表示およびロジックの変更はなし。

## 動作確認

- [ ] PC版 ContextRail WritingRail に「一年前の今日」と表示される
- [ ] モバイル版 Home タブに「一年前の今日」と表示される
- [ ] `${yearsAgo}年前` のサブラベルが引き続き正常に表示される
