### PR TITLE
refactor(rail): CollectionRail の「おすすめ」を「人気のフェイス」に変更

### DIFF
--- a/src/components/ui/ContextRail.tsx
+++ b/src/components/ui/ContextRail.tsx
@@ -264,7 +264,7 @@ const CollectionRail = () => {
       )}
 
       {/* おすすめフェイス */}
-      <RailCard title="おすすめ">
+      <RailCard title="人気のフェイス">
         <div style={{ display: "flex", flexDirection: "column", gap: 10 }}>
           {RECOMMENDED_FACES_MOCK.map((rec, i) => (
             <div key={rec.handle} style={{ display: "flex", alignItems: "center", gap: 10 }}>


### PR DESCRIPTION
## 概要

Collection タブのコンテキストレイル（`CollectionRail`）にある「おすすめ」セクションのタイトルを「人気のフェイス」に変更する。「おすすめ」はアルゴリズム推薦を連想させる表現だが、実態は人気フェイスのリストであるため、内容を正確に表すラベルに修正した。

## 関連Issue

Closes #164

## 変更点

- `src/components/ui/ContextRail.tsx` — `CollectionRail` 内 `<RailCard title="おすすめ">` → `<RailCard title="人気のフェイス">`

表示データ（`RECOMMENDED_FACES_MOCK`）・レイアウトの変更はなし。

## 動作確認

- [ ] PC版 Collection タブのコンテキストレイルに「人気のフェイス」と表示される
