### PR TITLE
feat(design): フェイスカードリデザイン・アイコン写真対応・検索フィルター強化

### DIFF
--- a/src/components/face/FacesClient.tsx
+++ b/src/components/face/FacesClient.tsx
@@ -3,8 +3,10 @@
 import { useState, useMemo } from "react";
 import Link from "next/link";
 import type { Face } from "@/types/face";
-import { getFaceTitle, getFaceColor, getFaceKanji } from "@/lib/display";
+import { getFaceTitle, getFaceColor, getFaceKanji, createLookupMap } from "@/lib/display";
 import { activityRepository } from "@/repositories/activity-repository";
+import { userRepository } from "@/repositories/user-repository";
+import SeedRow from "@/components/ui/SeedRow";
 import CreateFaceModal from "./CreateFaceModal";
 
 type Props = {
@@ -81,30 +83,22 @@ const FacesClient = ({ initialFaces }: Props) => {
     [faceStats]
   );
 
+  const faceMap = useMemo(() => createLookupMap(faces, (f) => f.id), [faces]);
+  const userMap = useMemo(() => createLookupMap(userRepository.listAll(), (u) => u.id), []);
+
+  const matchingSeeds = useMemo(() => {
+    if (!searchQuery.trim()) return [];
+    const q = searchQuery.toLowerCase();
+    const faceIds = new Set(faces.map((f) => f.id));
+    return activityRepository.listAll()
+      .filter((a) => faceIds.has(a.faceId) && a.body.toLowerCase().includes(q));
+  }, [searchQuery, faces]);
+
   return (
     <main style={{ display: "flex", flexDirection: "column", paddingBottom: 24 }}>
-      {/* ページタイトル */}
-      <div style={{ padding: "4px 18px 14px" }}>
-        <div style={{ display: "flex", alignItems: "baseline", justifyContent: "space-between" }}>
-          <div
-            style={{
-              fontSize: 22,
-              fontWeight: 700,
-              color: "var(--mf-brand)",
-              letterSpacing: -0.3,
-              fontFamily: "var(--mf-font-sans)",
-            }}
-          >
-            振り返り
-          </div>
-          <div style={{ fontSize: 12, color: "var(--mf-text-sub)", fontWeight: 500 }}>
-            {faces.length} フェイス · {totalSeeds} シード
-          </div>
-        </div>
-      </div>
 
       {/* 検索バー */}
-      <div style={{ padding: "0 18px 8px" }}>
+      <div style={{ padding: "20px 18px 8px" }}>
         <div
           style={{
             display: "flex",
@@ -124,7 +118,7 @@ const FacesClient = ({ initialFaces }: Props) => {
             type="text"
             value={searchQuery}
             onChange={(e) => setSearchQuery(e.target.value)}
-            placeholder="自分のシードを全文検索"
+            placeholder="自分のフェイス・シードを検索"
             style={{
               flex: 1,
               border: "none",
@@ -149,6 +143,91 @@ const FacesClient = ({ initialFaces }: Props) => {
         </div>
       </div>
 
+      {/* 検索結果 */}
+      {searchQuery.trim() && (
+        <div style={{ padding: "0 0 16px" }}>
+          {/* フェイス結果 */}
+          <div style={{ padding: "12px 20px 6px" }}>
+            <span style={{ fontSize: 11, fontWeight: 700, color: "var(--mf-text-muted)", letterSpacing: 0.5, textTransform: "uppercase" }}>
+              フェイス ({filteredFaces.length})
+            </span>
+          </div>
+          {filteredFaces.length === 0 ? (
+            <p style={{ fontSize: 12.5, color: "var(--mf-text-muted)", padding: "4px 20px" }}>該当なし</p>
+          ) : (
+            <div style={{ padding: "0 20px", display: "grid", gridTemplateColumns: "repeat(auto-fill, minmax(200px, 1fr))", gap: 12 }}>
+              {filteredFaces.map((face) => {
+                const stats = faceStats.get(face.id);
+                const color = getFaceColor(face.id);
+                return (
+                  <Link key={face.id} href={`/faces/${face.id}`} style={{ textDecoration: "none" }}>
+                    <div style={{ height: 200, borderRadius: 14, overflow: "hidden", background: "var(--mf-surface)", border: "0.5px solid var(--mf-line)", display: "flex", flexDirection: "column" }}>
+                      <div style={{
+                        height: 130, flexShrink: 0,
+                        background: face.imageUrl ? undefined : color,
+                        backgroundImage: face.imageUrl ? `url(${face.imageUrl})` : undefined,
+                        backgroundSize: "cover", backgroundPosition: "center",
+                        padding: 10, display: "flex", alignItems: "flex-start", justifyContent: "flex-end",
+                      }}>
+                        {face.isPrivate && (
+                          <div style={{ display: "flex", alignItems: "center", gap: 3, padding: "3px 7px", background: "rgba(20,24,36,0.32)", borderRadius: 999, backdropFilter: "blur(8px)", WebkitBackdropFilter: "blur(8px)" }}>
+                            <svg width={10} height={10} viewBox="0 0 14 14" fill="none" stroke="#fff" strokeWidth={1.5} strokeLinecap="round" strokeLinejoin="round">
+                              <rect x={2.5} y={6} width={9} height={6.5} rx={1.2} /><path d="M4.5 6V4a2.5 2.5 0 015 0v2" />
+                            </svg>
+                            <span style={{ fontSize: 9, color: "#fff", fontWeight: 700, letterSpacing: 0.3 }}>非公開</span>
+                          </div>
+                        )}
+                      </div>
+                      <div style={{ padding: "11px 13px 12px", flex: 1, display: "flex", flexDirection: "column", justifyContent: "space-between" }}>
+                        <div style={{ display: "flex", alignItems: "center", justifyContent: "space-between", gap: 8 }}>
+                          <div style={{ fontSize: 16, fontWeight: 700, color: "var(--mf-brand)", overflow: "hidden", textOverflow: "ellipsis", whiteSpace: "nowrap", flex: 1, minWidth: 0 }}>
+                            {getFaceTitle(face)}
+                          </div>
+                          <span style={{ flexShrink: 0 }}>
+                            <b style={{ color: "var(--mf-text)", fontWeight: 700, fontSize: 17 }}>{stats?.total ?? 0}</b>
+                            <span style={{ fontSize: 10, color: "var(--mf-text-muted)", marginLeft: 2 }}>シード</span>
+                          </span>
+                        </div>
+                        <div style={{ fontSize: 10.5, color: "var(--mf-text-muted)" }}>
+                          {stats?.lastDate ? stats.lastDate.replace(/-/g, "/") : "—"}
+                        </div>
+                      </div>
+                    </div>
+                  </Link>
+                );
+              })}
+            </div>
+          )}
+
+          {/* シード結果 */}
+          <div style={{ padding: "16px 20px 6px" }}>
+            <span style={{ fontSize: 11, fontWeight: 700, color: "var(--mf-text-muted)", letterSpacing: 0.5, textTransform: "uppercase" }}>
+              シード ({matchingSeeds.length})
+            </span>
+          </div>
+          {matchingSeeds.length === 0 ? (
+            <p style={{ fontSize: 12.5, color: "var(--mf-text-muted)", padding: "4px 20px" }}>該当なし</p>
+          ) : (
+            <div style={{ padding: "0 20px" }}>
+              {matchingSeeds.map((act) => {
+                const face = faceMap.get(act.faceId);
+                const owner = userMap.get(act.userId);
+                if (!face) return null;
+                return (
+                  <SeedRow
+                    key={act.id}
+                    activity={act}
+                    face={face}
+                    handle={owner?.handle}
+                  />
+                );
+              })}
+            </div>
+          )}
+        </div>
+      )}
+
+      {!searchQuery.trim() && <>
       {/* ソートコントロール */}
       <div
         style={{
@@ -313,7 +392,7 @@ const FacesClient = ({ initialFaces }: Props) => {
           style={{
             padding: "0 20px 32px",
             display: "grid",
-            gridTemplateColumns: "repeat(auto-fill, minmax(150px, 1fr))",
+            gridTemplateColumns: "repeat(auto-fill, minmax(200px, 1fr))",
             gap: 12,
           }}
         >
@@ -329,7 +408,7 @@ const FacesClient = ({ initialFaces }: Props) => {
               >
                 <div
                   style={{
-                    height: 156,
+                    height: 200,
                     borderRadius: 14,
                     overflow: "hidden",
                     background: "var(--mf-surface)",
@@ -339,36 +418,22 @@ const FacesClient = ({ initialFaces }: Props) => {
                     flexDirection: "column",
                   }}
                 >
-                  {/* カラーバンド (56px) */}
+                  {/* 画像エリア */}
                   <div
                     style={{
-                      height: 56,
-                      background: color,
-                      padding: 12,
+                      height: 130,
+                      background: face.imageUrl ? undefined : color,
+                      backgroundImage: face.imageUrl ? `url(${face.imageUrl})` : undefined,
+                      backgroundSize: "cover",
+                      backgroundPosition: "center",
+                      padding: 10,
                       display: "flex",
                       alignItems: "flex-start",
-                      justifyContent: "space-between",
+                      justifyContent: "flex-end",
                       flexShrink: 0,
                     }}
                   >
-                    <div
-                      style={{
-                        width: 30,
-                        height: 30,
-                        borderRadius: 8,
-                        background: "rgba(255,255,255,0.22)",
-                        display: "flex",
-                        alignItems: "center",
-                        justifyContent: "center",
-                        fontFamily: "var(--mf-font-serif)",
-                        fontSize: 14,
-                        fontWeight: 500,
-                        color: "#fff",
-                      }}
-                    >
-                      {kanji}
-                    </div>
-                    {face.isPrivate ? (
+                    {face.isPrivate && (
                       <div style={{
                         display: "flex", alignItems: "center", gap: 3,
                         padding: "3px 7px",
@@ -383,19 +448,15 @@ const FacesClient = ({ initialFaces }: Props) => {
                         </svg>
                         <span style={{ fontSize: 9, color: "#fff", fontWeight: 700, letterSpacing: 0.3 }}>非公開</span>
                       </div>
-                    ) : (
-                      <svg width={16} height={16} viewBox="0 0 18 18" fill="rgba(255,255,255,0.85)">
-                        <circle cx={3} cy={9} r={1.5} /><circle cx={9} cy={9} r={1.5} /><circle cx={15} cy={9} r={1.5} />
-                      </svg>
                     )}
                   </div>
 
                   {/* カード本文 */}
                   <div style={{ padding: "11px 13px 12px", flex: 1, display: "flex", flexDirection: "column", justifyContent: "space-between" }}>
-                    <div>
+                    <div style={{ display: "flex", alignItems: "center", justifyContent: "space-between", gap: 8 }}>
                       <div
                         style={{
-                          fontSize: 14.5,
+                          fontSize: 16,
                           fontWeight: 700,
                           color: "var(--mf-brand)",
                           overflow: "hidden",
@@ -403,42 +464,19 @@ const FacesClient = ({ initialFaces }: Props) => {
                           whiteSpace: "nowrap",
                           letterSpacing: 0.1,
                           lineHeight: 1.2,
+                          flex: 1,
+                          minWidth: 0,
                         }}
                       >
                         {getFaceTitle(face)}
                       </div>
-
-                      {/* 統計行 */}
-                      <div
-                        style={{
-                          display: "flex",
-                          alignItems: "baseline",
-                          gap: 6,
-                          marginTop: 5,
-                        }}
-                      >
-                        <span>
-                          <b style={{ color: "var(--mf-text)", fontWeight: 700, fontSize: 17 }}>
-                            {stats?.total ?? 0}
-                          </b>
-                          <span style={{ fontSize: 10, color: "var(--mf-text-muted)", marginLeft: 2 }}>シード</span>
-                        </span>
-                        {stats && stats.monthly > 0 && (
-                          <span
-                            style={{
-                              marginLeft: "auto",
-                              fontSize: 10.5,
-                              color,
-                              fontWeight: 700,
-                            }}
-                          >
-                            +{stats.monthly}/月
-                          </span>
-                        )}
-                      </div>
+                      <span style={{ flexShrink: 0, textAlign: "right" }}>
+                        <b style={{ color: "var(--mf-text)", fontWeight: 700, fontSize: 17 }}>
+                          {stats?.total ?? 0}
+                        </b>
+                        <span style={{ fontSize: 10, color: "var(--mf-text-muted)", marginLeft: 2 }}>シード</span>
+                      </span>
                     </div>
-
-                    {/* 最終投稿日 */}
                     <div style={{ fontSize: 10.5, color: "var(--mf-text-muted)" }}>
                       {stats?.lastDate ? stats.lastDate.replace(/-/g, "/") : "—"}
                     </div>
@@ -496,16 +534,21 @@ const FacesClient = ({ initialFaces }: Props) => {
                       width: 44,
                       height: 44,
                       borderRadius: 12,
-                      background: color,
-                      display: "flex",
+                      background: face.imageUrl ? undefined : color,
+                      backgroundImage: face.imageUrl ? `url(${face.imageUrl})` : undefined,
+                      backgroundSize: "cover",
+                      backgroundPosition: "center",
+                      flexShrink: 0,
+                      display: face.imageUrl ? "block" : "flex",
                       alignItems: "center",
                       justifyContent: "center",
-                      flexShrink: 0,
                     }}
                   >
-                    <span style={{ fontFamily: "var(--mf-font-serif)", fontSize: 18, fontWeight: 600, color: "#fff" }}>
-                      {kanji}
-                    </span>
+                    {!face.imageUrl && (
+                      <span style={{ fontFamily: "var(--mf-font-serif)", fontSize: 18, fontWeight: 600, color: "#fff" }}>
+                        {kanji}
+                      </span>
+                    )}
                   </div>
                   <div style={{ flex: 1, minWidth: 0 }}>
                     <div style={{ fontSize: 14, fontWeight: 700, color: "var(--mf-brand)", overflow: "hidden", textOverflow: "ellipsis", whiteSpace: "nowrap" }}>
@@ -547,6 +590,8 @@ const FacesClient = ({ initialFaces }: Props) => {
           </button>
         </div>
       )}
+
+      </>}
 
       <CreateFaceModal
         isOpen={isModalOpen}

--- a/src/components/home/HomeProfile.tsx
+++ b/src/components/home/HomeProfile.tsx
@@ -12,22 +12,12 @@ const HomeProfile = () => {
     <div style={{ display: "flex", flexDirection: "column", gap: 16, padding: "20px 28px 12px" }}>
       {/* アバター・名前 */}
       <div style={{ display: "flex", alignItems: "center", gap: 12 }}>
-        <div
-          style={{
-            width: 44,
-            height: 44,
-            borderRadius: "50%",
-            background: "var(--mf-brand)",
-            color: "#fff",
-            display: "flex",
-            alignItems: "center",
-            justifyContent: "center",
-            fontSize: 18,
-            fontWeight: 700,
-            flexShrink: 0,
-          }}
-        >
-          {user.name.slice(0, 1)}
+        <div style={{ width: 44, height: 44, borderRadius: "50%", overflow: "hidden", flexShrink: 0 }}>
+          <img
+            src={user.avatarUrl}
+            alt={user.name}
+            style={{ width: "100%", height: "100%", objectFit: "cover", display: "block" }}
+          />
         </div>
         <div>
           <div style={{ fontSize: 16, fontWeight: 700, color: "var(--mf-brand)" }}>

--- a/src/components/notifications/NotificationList.tsx
+++ b/src/components/notifications/NotificationList.tsx
@@ -26,12 +26,13 @@ type NotifItemProps = {
   notification: Notification;
   faceName?: string;
   faceId?: string;
+  faceImageUrl?: string;
   handle?: string;
   preview: string;
   activityId?: string;
 };
 
-const NotifItem = ({ notification, faceName, faceId, handle, preview, activityId }: NotifItemProps) => {
+const NotifItem = ({ notification, faceName, faceId, faceImageUrl, handle, preview, activityId }: NotifItemProps) => {
   const isUnread = notification.createdAt >= UNREAD_CUTOFF;
   const isLink = notification.type === "link";
 
@@ -40,7 +41,7 @@ const NotifItem = ({ notification, faceName, faceId, handle, preview, activityId
     : { label: "更新", bg: "rgba(212,146,42,0.10)", color: "var(--mf-accent)" };
 
   const mockFace = faceId
-    ? { id: faceId, name: faceName ?? "", userId: "", isPrivate: false }
+    ? { id: faceId, name: faceName ?? "", userId: "", isPrivate: false, imageUrl: faceImageUrl }
     : null;
 
   return (
@@ -234,6 +235,7 @@ const NotificationList = () => {
                     notification={notification}
                     faceName={linkedFace ? getFaceTitle(linkedFace) : undefined}
                     faceId={linkedFace?.id}
+                    faceImageUrl={linkedFace?.imageUrl}
                     handle={fromUser.handle}
                     preview={activity?.body ?? "リンクされたシードです"}
                     activityId={notification.activityId}
@@ -248,6 +250,7 @@ const NotificationList = () => {
                   notification={notification}
                   faceName={face ? getFaceTitle(face) : undefined}
                   faceId={face?.id}
+                  faceImageUrl={face?.imageUrl}
                   handle={fromUser.handle}
                   preview={face ? `${getFaceTitle(face)} に新しいシードが投稿されました` : "サブスク中のフェイスが更新されました"}
                 />

--- a/src/components/subscriptions/SubscriptionFeed.tsx
+++ b/src/components/subscriptions/SubscriptionFeed.tsx
@@ -9,13 +9,15 @@ import { subscriptionRepository } from "@/repositories/subscription-repository";
 import SeedRow from "@/components/ui/SeedRow";
 import DateBar from "@/components/ui/DateBar";
 import FaceBadge from "@/components/ui/FaceBadge";
-import { createLookupMap, getFaceTitle } from "@/lib/display";
+import { createLookupMap, getFaceTitle, getFaceColor } from "@/lib/display";
 
 type Tab = "timeline" | "subscriptions";
 
 const SubscriptionFeed = () => {
   const [activeTab, setActiveTab] = useState<Tab>("timeline");
   const [selectedFaceId, setSelectedFaceId] = useState<string | null>(null);
+  const [showFaceFilter, setShowFaceFilter] = useState(false);
+  const [searchQuery, setSearchQuery] = useState("");
 
   const subscribedFaceIds = subscriptionRepository.getSubscribedFaceIds();
   const subscribedActivities = activityRepository.listByFaceIds(subscribedFaceIds);
@@ -32,13 +34,37 @@ const SubscriptionFeed = () => {
   const faceMap = createLookupMap(subscribedFaces, (face) => face.id);
   const userMap = createLookupMap(userRepository.listAll(), (user) => user.id);
 
-  const filteredActivities = useMemo(
-    () =>
-      selectedFaceId
-        ? subscribedActivities.filter((a) => a.faceId === selectedFaceId)
-        : subscribedActivities,
-    [subscribedActivities, selectedFaceId]
-  );
+  const filteredActivities = useMemo(() => {
+    let result = selectedFaceId
+      ? subscribedActivities.filter((a) => a.faceId === selectedFaceId)
+      : subscribedActivities;
+    if (searchQuery.trim()) {
+      const q = searchQuery.toLowerCase();
+      result = result.filter((a) => {
+        const face = faceMap.get(a.faceId);
+        return (
+          a.body.toLowerCase().includes(q) ||
+          (face && getFaceTitle(face).toLowerCase().includes(q))
+        );
+      });
+    }
+    return result;
+  }, [subscribedActivities, selectedFaceId, searchQuery, faceMap]);
+
+  const matchingFaces = useMemo(() => {
+    if (!searchQuery.trim()) return [];
+    const q = searchQuery.toLowerCase();
+    return subscribedFaces.filter((f) =>
+      getFaceTitle(f).toLowerCase().includes(q) ||
+      f.description?.toLowerCase().includes(q)
+    );
+  }, [searchQuery, subscribedFaces]);
+
+  const matchingSeeds = useMemo(() => {
+    if (!searchQuery.trim()) return [];
+    const q = searchQuery.toLowerCase();
+    return subscribedActivities.filter((a) => a.body.toLowerCase().includes(q));
+  }, [searchQuery, subscribedActivities]);
 
   // タイムラインを日付でグループ化
   const grouped = useMemo(() => {
@@ -62,22 +88,9 @@ const SubscriptionFeed = () => {
   ];
 
   return (
-    <div>
-      {/* ページタイトル */}
-      <div style={{ padding: "4px 18px 14px" }}>
-        <div
-          style={{
-            fontSize: 22,
-            fontWeight: 700,
-            color: "var(--mf-brand)",
-            letterSpacing: -0.3,
-            fontFamily: "var(--mf-font-sans)",
-            marginBottom: 12,
-          }}
-        >
-          収集
-        </div>
-        {/* 検索バー */}
+    <div onClick={() => setShowFaceFilter(false)}>
+      {/* 検索バー */}
+      <div style={{ padding: "20px 18px 14px" }}>
         <div
           style={{
             display: "flex",
@@ -92,9 +105,32 @@ const SubscriptionFeed = () => {
           <svg width={16} height={16} viewBox="0 0 18 18" fill="none" stroke="var(--mf-text-muted)" strokeWidth={1.6} strokeLinecap="round" strokeLinejoin="round">
             <circle cx={8} cy={8} r={5.5} /><path d="M12.2 12.2L16 16" />
           </svg>
-          <div style={{ flex: 1, color: "var(--mf-text-muted)", fontSize: 13, fontFamily: "var(--mf-font-sans)" }}>
-            フェイス・シードを検索
-          </div>
+          <input
+            type="text"
+            value={searchQuery}
+            onChange={(e) => setSearchQuery(e.target.value)}
+            placeholder="他人のフェイス・シードを検索"
+            style={{
+              flex: 1,
+              border: "none",
+              background: "transparent",
+              fontSize: 13,
+              color: "var(--mf-text)",
+              outline: "none",
+              fontFamily: "var(--mf-font-sans)",
+            }}
+          />
+          {searchQuery && (
+            <button
+              type="button"
+              onClick={() => setSearchQuery("")}
+              style={{ background: "none", border: "none", cursor: "pointer", color: "var(--mf-text-muted)", padding: 0 }}
+            >
+              <svg width={14} height={14} viewBox="0 0 14 14" fill="none" stroke="currentColor" strokeWidth={1.5} strokeLinecap="round">
+                <path d="M2 2l10 10M12 2L2 12" />
+              </svg>
+            </button>
+          )}
         </div>
       </div>
 
@@ -137,74 +173,190 @@ const SubscriptionFeed = () => {
         ))}
       </div>
 
-      {activeTab === "timeline" && (
-        <>
-          {/* サブスク中フェイスの横スクロール行 */}
-          {subscribedFaces.length > 0 && (
-            <div
-              style={{
-                padding: "14px 18px 8px",
-                borderBottom: "0.5px solid var(--mf-line)",
-                overflowX: "auto",
-                display: "flex",
-                gap: 12,
-              }}
-              className="mf-scroll"
-            >
-              {subscribedFaces.map((face) => {
-                const hasUnread = subscribedActivities.some((a) => a.faceId === face.id);
-                const isSelected = selectedFaceId === face.id;
+      {/* 検索結果 */}
+      {searchQuery.trim() ? (
+        <div style={{ paddingBottom: 16 }}>
+          {/* フェイス結果 */}
+          <div style={{ padding: "12px 20px 6px" }}>
+            <span style={{ fontSize: 11, fontWeight: 700, color: "var(--mf-text-muted)", letterSpacing: 0.5, textTransform: "uppercase" }}>
+              フェイス ({matchingFaces.length})
+            </span>
+          </div>
+          {matchingFaces.length === 0 ? (
+            <p style={{ fontSize: 12.5, color: "var(--mf-text-muted)", padding: "4px 20px" }}>該当なし</p>
+          ) : (
+            <div style={{ padding: "0 20px", display: "grid", gridTemplateColumns: "repeat(auto-fill, minmax(200px, 1fr))", gap: 12 }}>
+              {matchingFaces.map((face) => {
                 const owner = userMap.get(face.userId);
+                const seedCount = subscribedActivities.filter((a) => a.faceId === face.id).length;
+                const lastAct = subscribedActivities.find((a) => a.faceId === face.id);
+                const color = getFaceColor(face.id);
                 return (
-                  <button
-                    key={face.id}
-                    type="button"
-                    onClick={() => setSelectedFaceId(isSelected ? null : face.id)}
-                    style={{
-                      display: "flex",
-                      flexDirection: "column",
-                      alignItems: "center",
-                      gap: 6,
-                      flexShrink: 0,
-                      width: 52,
-                      background: "none",
-                      border: "none",
-                      padding: 0,
-                      cursor: "pointer",
-                      opacity: selectedFaceId && !isSelected ? 0.4 : 1,
-                      transition: "opacity 0.15s",
-                    }}
-                  >
-                    <div
-                      style={{
-                        borderRadius: 12,
-                        boxShadow: isSelected
-                          ? "0 0 0 2px var(--mf-bg-light), 0 0 0 3.5px var(--mf-brand)"
-                          : hasUnread
-                          ? "0 0 0 2px var(--mf-bg-light), 0 0 0 3.5px var(--mf-accent)"
-                          : "none",
-                        flexShrink: 0,
-                      }}
-                    >
-                      <FaceBadge face={face} size={46} radius={12} />
+                  <Link key={face.id} href={`/faces/${face.id}`} style={{ textDecoration: "none" }}>
+                    <div style={{ height: 200, borderRadius: 14, overflow: "hidden", background: "var(--mf-surface)", border: "0.5px solid var(--mf-line)", display: "flex", flexDirection: "column" }}>
+                      <div style={{
+                        height: 130, flexShrink: 0,
+                        background: face.imageUrl ? undefined : color,
+                        backgroundImage: face.imageUrl ? `url(${face.imageUrl})` : undefined,
+                        backgroundSize: "cover", backgroundPosition: "center",
+                      }} />
+                      <div style={{ padding: "11px 13px 12px", flex: 1, display: "flex", flexDirection: "column", justifyContent: "space-between" }}>
+                        <div style={{ display: "flex", alignItems: "center", justifyContent: "space-between", gap: 8 }}>
+                          <div style={{ fontSize: 16, fontWeight: 700, color: "var(--mf-brand)", overflow: "hidden", textOverflow: "ellipsis", whiteSpace: "nowrap", flex: 1, minWidth: 0 }}>
+                            {getFaceTitle(face)}
+                          </div>
+                          <span style={{ flexShrink: 0 }}>
+                            <b style={{ color: "var(--mf-text)", fontWeight: 700, fontSize: 17 }}>{seedCount}</b>
+                            <span style={{ fontSize: 10, color: "var(--mf-text-muted)", marginLeft: 2 }}>シード</span>
+                          </span>
+                        </div>
+                        <div style={{ fontSize: 10.5, color: "var(--mf-text-muted)" }}>
+                          {owner ? `@${owner.handle ?? owner.name}` : lastAct?.createdAt.slice(0, 10).replace(/-/g, "/") ?? "—"}
+                        </div>
+                      </div>
                     </div>
-                    <span
-                      style={{
-                        fontSize: 10,
-                        color: isSelected ? "var(--mf-brand)" : "var(--mf-text-sub)",
-                        fontWeight: isSelected ? 700 : 400,
-                        maxWidth: 52,
-                        overflow: "hidden",
-                        textOverflow: "ellipsis",
-                        whiteSpace: "nowrap",
-                        textAlign: "center",
-                      }}
-                    >
-                      {owner?.handle ?? getFaceTitle(face)}
-                    </span>
-                  </button>
+                  </Link>
                 );
               })}
+            </div>
+          )}
+
+          {/* シード結果 */}
+          <div style={{ padding: "16px 20px 6px" }}>
+            <span style={{ fontSize: 11, fontWeight: 700, color: "var(--mf-text-muted)", letterSpacing: 0.5, textTransform: "uppercase" }}>
+              シード ({matchingSeeds.length})
+            </span>
+          </div>
+          {matchingSeeds.length === 0 ? (
+            <p style={{ fontSize: 12.5, color: "var(--mf-text-muted)", padding: "4px 20px" }}>該当なし</p>
+          ) : (
+            <div style={{ padding: "0 20px" }}>
+              {matchingSeeds.map((act) => {
+                const face = faceMap.get(act.faceId);
+                const owner = userMap.get(act.userId);
+                if (!face) return null;
+                return (
+                  <SeedRow
+                    key={act.id}
+                    activity={act}
+                    face={face}
+                    handle={owner?.handle}
+                  />
+                );
+              })}
+            </div>
+          )}
+        </div>
+      ) : null}
+
+      {!searchQuery.trim() && activeTab === "timeline" && (
+        <>
+          {/* フィルターボタン */}
+          {subscribedFaces.length > 0 && (
+            <div style={{ padding: "10px 18px 8px", borderBottom: "0.5px solid var(--mf-line)", position: "relative" }}>
+              <button
+                type="button"
+                onClick={(e) => { e.stopPropagation(); setShowFaceFilter((p) => !p); }}
+                style={{
+                  display: "inline-flex",
+                  alignItems: "center",
+                  gap: 6,
+                  padding: "6px 12px",
+                  borderRadius: 999,
+                  background: selectedFaceId ? "var(--mf-brand)" : "var(--mf-surface)",
+                  border: `1px solid ${selectedFaceId ? "var(--mf-brand)" : "var(--mf-line)"}`,
+                  cursor: "pointer",
+                  fontSize: 12.5,
+                  fontWeight: 600,
+                  color: selectedFaceId ? "#fff" : "var(--mf-text-sub)",
+                }}
+              >
+                <svg width={13} height={13} viewBox="0 0 14 14" fill="none" stroke="currentColor" strokeWidth={1.6} strokeLinecap="round" strokeLinejoin="round">
+                  <path d="M1 3h12M3 7h8M5 11h4" />
+                </svg>
+                {selectedFaceId
+                  ? getFaceTitle(faceMap.get(selectedFaceId)!)
+                  : "フェイスで絞り込み"}
+                {selectedFaceId && (
+                  <span
+                    onClick={(e) => { e.stopPropagation(); setSelectedFaceId(null); }}
+                    style={{ display: "flex", alignItems: "center", marginLeft: 2, opacity: 0.8 }}
+                  >
+                    <svg width={12} height={12} viewBox="0 0 12 12" fill="none" stroke="currentColor" strokeWidth={1.8} strokeLinecap="round">
+                      <path d="M2 2l8 8M10 2L2 10" />
+                    </svg>
+                  </span>
+                )}
+              </button>
+
+              {/* プルダウン */}
+              {showFaceFilter && (
+                <div
+                  onClick={(e) => e.stopPropagation()}
+                  style={{
+                    position: "absolute",
+                    top: "calc(100% - 4px)",
+                    left: 18,
+                    zIndex: 30,
+                    background: "var(--mf-surface)",
+                    borderRadius: 12,
+                    border: "0.5px solid var(--mf-line)",
+                    boxShadow: "0 8px 24px rgba(30,42,74,0.12)",
+                    overflow: "hidden",
+                    minWidth: 200,
+                  }}
+                >
+                  {subscribedFaces.map((face) => {
+                    const isSelected = selectedFaceId === face.id;
+                    const hasUnread = subscribedActivities.some((a) => a.faceId === face.id);
+                    return (
+                      <button
+                        key={face.id}
+                        type="button"
+                        onClick={() => {
+                          setSelectedFaceId(isSelected ? null : face.id);
+                          setShowFaceFilter(false);
+                        }}
+                        style={{
+                          width: "100%",
+                          display: "flex",
+                          alignItems: "center",
+                          gap: 10,
+                          padding: "9px 14px",
+                          background: isSelected ? "var(--mf-hover)" : "transparent",
+                          border: "none",
+                          cursor: "pointer",
+                          textAlign: "left",
+                        }}
+                      >
+                        <div style={{
+                          borderRadius: 9,
+                          boxShadow: hasUnread && !isSelected ? "0 0 0 2px var(--mf-surface), 0 0 0 3px var(--mf-accent)" : "none",
+                          flexShrink: 0,
+                        }}>
+                          <FaceBadge face={face} size={32} radius={9} />
+                        </div>
+                        <span style={{
+                          fontSize: 13,
+                          fontWeight: isSelected ? 700 : 500,
+                          color: isSelected ? "var(--mf-brand)" : "var(--mf-text)",
+                          flex: 1,
+                          overflow: "hidden",
+                          textOverflow: "ellipsis",
+                          whiteSpace: "nowrap",
+                        }}>
+                          {getFaceTitle(face)}
+                        </span>
+                        {isSelected && (
+                          <svg width={14} height={14} viewBox="0 0 14 14" fill="none" stroke="var(--mf-brand)" strokeWidth={2} strokeLinecap="round" strokeLinejoin="round">
+                            <path d="M2 7l4 4 6-6" />
+                          </svg>
+                        )}
+                      </button>
+                    );
+                  })}
+                </div>
+              )}
             </div>
           )}
 
@@ -240,7 +392,7 @@ const SubscriptionFeed = () => {
         </>
       )}
 
-      {activeTab === "subscriptions" && (
+      {!searchQuery.trim() && activeTab === "subscriptions" && (
         <div>
           {subscribedFaces.length === 0 ? (
             <EmptyState />
@@ -330,7 +482,7 @@ const EmptyState = () => (
           <circle cx={8} cy={8} r={5.5} /><path d="M12.2 12.2L16 16" />
         </svg>
         <div style={{ flex: 1, color: "var(--mf-text-muted)", fontSize: 13.5, fontFamily: "var(--mf-font-sans)" }}>
-          フェイス・シードを検索
+          他人のフェイス・シードを検索
         </div>
       </div>
     </div>

--- a/src/components/ui/AppHeader.tsx
+++ b/src/components/ui/AppHeader.tsx
@@ -64,19 +64,18 @@ const AppHeader = () => {
               width: 30,
               height: 30,
               borderRadius: "50%",
-              background: "var(--mf-brand)",
-              color: "#F8F6F1",
-              display: "flex",
-              alignItems: "center",
-              justifyContent: "center",
-              fontSize: 12,
-              fontWeight: 700,
+              overflow: "hidden",
               flexShrink: 0,
               border: "none",
               cursor: "pointer",
+              padding: 0,
             }}
           >
-            {user.name.slice(0, 1)}
+            <img
+              src={user.avatarUrl}
+              alt={user.name}
+              style={{ width: "100%", height: "100%", objectFit: "cover", display: "block" }}
+            />
           </button>
         </div>
       </header>

--- a/src/components/ui/FaceBadge.tsx
+++ b/src/components/ui/FaceBadge.tsx
@@ -17,7 +17,10 @@ const FaceBadge = ({ face, size = 36, radius = 10 }: FaceBadgeProps) => {
         width: size,
         height: size,
         borderRadius: radius,
-        background: color,
+        background: face.imageUrl ? undefined : color,
+        backgroundImage: face.imageUrl ? `url(${face.imageUrl})` : undefined,
+        backgroundSize: "cover",
+        backgroundPosition: "center",
         color: "#fff",
         fontFamily: "var(--mf-font-serif)",
         fontSize: size * 0.48,
@@ -28,7 +31,7 @@ const FaceBadge = ({ face, size = 36, radius = 10 }: FaceBadgeProps) => {
         flexShrink: 0,
       }}
     >
-      {kanji}
+      {!face.imageUrl && kanji}
     </div>
   );
 };

--- a/src/components/ui/FaceNavItem.tsx
+++ b/src/components/ui/FaceNavItem.tsx
@@ -33,7 +33,7 @@ const FaceNavItem = ({ face, activeFaceId, onClick }: Props) => {
           transition: "background 0.15s",
         }}
       >
-        <FaceBadge face={face} size={26} radius={7} />
+        <FaceBadge face={face} size={34} radius={9} />
         <span
           style={{
             flex: 1,

--- a/src/components/ui/SeedRow.tsx
+++ b/src/components/ui/SeedRow.tsx
@@ -196,6 +196,7 @@ const SeedRow = ({
               borderRadius: 14,
               overflow: "hidden",
               border: "0.5px solid var(--mf-line-soft)",
+              maxWidth: "50%",
             }}
           >
             {activity.imageUrls.slice(0, 4).map((url, i) => (

--- a/src/components/ui/SideNav.tsx
+++ b/src/components/ui/SideNav.tsx
@@ -272,27 +272,13 @@ const SideNav = () => {
             width: "100%",
           }}
         >
-          {faces[0] ? (
-            <FaceBadge face={faces[0]} size={36} radius={999} />
-          ) : (
-            <div
-              style={{
-                width: 36,
-                height: 36,
-                borderRadius: "50%",
-                background: "var(--mf-brand)",
-                display: "flex",
-                alignItems: "center",
-                justifyContent: "center",
-                color: "#fff",
-                fontSize: 14,
-                fontWeight: 600,
-                flexShrink: 0,
-              }}
-            >
-              {currentUser.name.slice(0, 1)}
-            </div>
-          )}
+          <div style={{ width: 44, height: 44, borderRadius: "50%", overflow: "hidden", flexShrink: 0 }}>
+            <img
+              src={currentUser.avatarUrl}
+              alt={currentUser.name}
+              style={{ width: "100%", height: "100%", objectFit: "cover", display: "block" }}
+            />
+          </div>
           <div style={{ flex: 1, minWidth: 0 }}>
             <div
               style={{


### PR DESCRIPTION
## 概要

フェイスアイコン・アバターの写真対応、ReflectionタブとCollectionタブのUIリデザイン、検索・フィルター機能の強化をまとめて実施しました。

## 変更点

- **FaceBadge / FaceNavItem / NotificationList**: フェイスに `imageUrl` が設定されている場合、カラー+漢字のフォールバックから写真表示に切り替え
- **AppHeader / SideNav / HomeProfile**: ユーザーアイコン表示箇所に `user.avatarUrl` の写真を適用
- **FacesClient (Reflection タブ)**:
  - フェイスカードを大型化（高さ 156px → 200px、幅 minmax 200px）
  - カード上部をカラー帯から `face.imageUrl` 背景画像（130px）に変更
  - フェイス名とシード数を横並び・フォント拡大
  - ページタイトル「振り返り」を削除し上部余白を確保
  - 検索結果にフェイスカードとシード一覧を表示
- **SubscriptionFeed (Collection タブ)**:
  - ページタイトル「収集」を削除し上部余白を確保
  - 検索バーを機能化（`searchQuery` ステートで絞り込み）
  - フェイス絞り込みをプルダウン形式（フェイス名表示）に変更
  - 検索結果にフェイスカードとシード一覧を表示
- **SeedRow**: 添付画像の表示サイズを `maxWidth: "50%"` に縮小

## 動作確認

- [ ] Reflection タブ: フェイスカードに写真が表示される
- [ ] Reflection タブ: 検索でフェイスカード・シードが絞り込まれる
- [ ] Collection タブ: 検索が機能する
- [ ] Collection タブ: フェイス絞り込みプルダウンが開閉・選択できる
- [ ] SideNav・通知リスト・ヘッダーでフェイス写真・アバターが表示される
- [ ] シード添付画像が半分サイズで表示される
