### PR TITLE
refactor(nav): SideNavバッジ廃止・ESLintエラー修正

### DIFF
--- a/src/components/face/FacesClient.tsx
+++ b/src/components/face/FacesClient.tsx
@@ -78,11 +78,6 @@ const FacesClient = ({ initialFaces }: Props) => {
     name: "名前順",
   };
 
-  const totalSeeds = useMemo(
-    () => Array.from(faceStats.values()).reduce((sum, s) => sum + s.total, 0),
-    [faceStats]
-  );
-
   const faceMap = useMemo(() => createLookupMap(faces, (f) => f.id), [faces]);
   const userMap = useMemo(() => createLookupMap(userRepository.listAll(), (u) => u.id), []);
 
@@ -398,7 +393,6 @@ const FacesClient = ({ initialFaces }: Props) => {
         >
           {filteredFaces.map((face) => {
             const color = getFaceColor(face.id);
-            const kanji = getFaceKanji(getFaceTitle(face));
             const stats = faceStats.get(face.id);
             return (
               <Link

--- a/src/components/home/HomeProfile.tsx
+++ b/src/components/home/HomeProfile.tsx
@@ -1,3 +1,4 @@
+import Image from "next/image";
 import { userRepository } from "@/repositories/user-repository";
 import { faceRepository } from "@/repositories/face-repository";
 import { activityRepository } from "@/repositories/activity-repository";
@@ -13,10 +14,12 @@ const HomeProfile = () => {
       {/* アバター・名前 */}
       <div style={{ display: "flex", alignItems: "center", gap: 12 }}>
         <div style={{ width: 44, height: 44, borderRadius: "50%", overflow: "hidden", flexShrink: 0 }}>
-          <img
+          <Image
             src={user.avatarUrl}
             alt={user.name}
-            style={{ width: "100%", height: "100%", objectFit: "cover", display: "block" }}
+            width={44}
+            height={44}
+            style={{ objectFit: "cover", display: "block" }}
           />
         </div>
         <div>

--- a/src/components/notifications/NotificationList.tsx
+++ b/src/components/notifications/NotificationList.tsx
@@ -7,7 +7,7 @@ import { faceRepository } from "@/repositories/face-repository";
 import { activityRepository } from "@/repositories/activity-repository";
 import { type Notification } from "@/types/notification";
 import { formatRelativeTime } from "@/lib/format-relative-time";
-import { createLookupMap, getFaceTitle, getFaceColor } from "@/lib/display";
+import { createLookupMap, getFaceTitle } from "@/lib/display";
 import FaceBadge from "@/components/ui/FaceBadge";
 import DateBar from "@/components/ui/DateBar";
 
@@ -32,7 +32,7 @@ type NotifItemProps = {
   activityId?: string;
 };
 
-const NotifItem = ({ notification, faceName, faceId, faceImageUrl, handle, preview, activityId }: NotifItemProps) => {
+const NotifItem = ({ notification, faceName, faceId, faceImageUrl, handle, preview }: NotifItemProps) => {
   const isUnread = notification.createdAt >= UNREAD_CUTOFF;
   const isLink = notification.type === "link";
 

--- a/src/components/ui/AppHeader.tsx
+++ b/src/components/ui/AppHeader.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import { useState } from "react";
+import Image from "next/image";
 import Link from "next/link";
 import Wordmark from "@/components/ui/Wordmark";
 import AccountMenu from "@/components/ui/AccountMenu";
@@ -71,10 +72,12 @@ const AppHeader = () => {
               padding: 0,
             }}
           >
-            <img
+            <Image
               src={user.avatarUrl}
               alt={user.name}
-              style={{ width: "100%", height: "100%", objectFit: "cover", display: "block" }}
+              width={30}
+              height={30}
+              style={{ objectFit: "cover", display: "block" }}
             />
           </button>
         </div>

--- a/src/components/ui/ContextRail.tsx
+++ b/src/components/ui/ContextRail.tsx
@@ -12,7 +12,6 @@ import type { Face } from "@/types/face";
 import FaceBadge from "./FaceBadge";
 import FaceChip from "./FaceChip";
 import RailCard from "./RailCard";
-import SeedRow from "./SeedRow";
 
 const REFERENCE_DATE = new Date("2026-03-31");
 

--- a/src/components/ui/SideNav.tsx
+++ b/src/components/ui/SideNav.tsx
@@ -1,18 +1,16 @@
 "use client";
 
 import { useState } from "react";
+import Image from "next/image";
 import Link from "next/link";
 import { usePathname, useRouter } from "next/navigation";
 import Wordmark from "@/components/ui/Wordmark";
-import FaceBadge from "@/components/ui/FaceBadge";
 import FaceNavItem from "@/components/ui/FaceNavItem";
 import AccountMenu from "@/components/ui/AccountMenu";
 import CreateFaceModal from "@/components/face/CreateFaceModal";
 import PostModal from "@/components/ui/PostModal";
 import { faceRepository } from "@/repositories/face-repository";
 import { userRepository } from "@/repositories/user-repository";
-import { notificationRepository } from "@/repositories/notification-repository";
-import { subscriptionRepository } from "@/repositories/subscription-repository";
 import type { Face } from "@/types/face";
 
 type NavItem = {
@@ -20,10 +18,7 @@ type NavItem = {
   label: string;
   jp: string;
   icon: (active: boolean) => React.ReactNode;
-  count?: number;
 };
-
-const UNREAD_CUTOFF = "2026-03-25";
 
 const HomeIcon = ({ active }: { active: boolean }) => (
   <svg width={22} height={22} viewBox="0 0 22 22" fill="none" stroke="currentColor" strokeWidth={1.6} strokeLinecap="round" strokeLinejoin="round">
@@ -68,16 +63,11 @@ const SideNav = () => {
   const currentUser = userRepository.getCurrentUser();
   const faces = faceRepository.listByUserId(currentUser.id);
 
-  const unreadNotifCount = notificationRepository.listAll().filter(
-    (n) => n.createdAt >= UNREAD_CUTOFF
-  ).length;
-  const subscribedCount = subscriptionRepository.getSubscribedFaceIds().length;
-
   const NAV_ITEMS: NavItem[] = [
     { href: "/",             label: "Home",         jp: "ホーム",  icon: (a) => <HomeIcon active={a} /> },
     { href: "/faces",        label: "Reflection",   jp: "振り返り", icon: (a) => <LayersIcon active={a} /> },
-    { href: "/subscriptions",label: "Collection",   jp: "蒐集",    icon: (a) => <CompassIcon active={a} />, count: subscribedCount > 0 ? 3 : undefined },
-    { href: "/notifications",label: "Notifications",jp: "通知",    icon: (a) => <BellIcon active={a} />, count: unreadNotifCount > 0 ? unreadNotifCount : undefined },
+    { href: "/subscriptions",label: "Collection",   jp: "蒐集",    icon: (a) => <CompassIcon active={a} /> },
+    { href: "/notifications",label: "Notifications",jp: "通知",    icon: (a) => <BellIcon active={a} /> },
   ];
 
   const activeFaceId = pathname.startsWith("/faces/")
@@ -149,25 +139,6 @@ const SideNav = () => {
                     {item.label}
                   </div>
                 </div>
-                {item.count && item.count > 0 ? (
-                  <div
-                    style={{
-                      minWidth: 18,
-                      height: 18,
-                      padding: "0 6px",
-                      borderRadius: 999,
-                      background: "var(--mf-accent)",
-                      color: "#fff",
-                      fontSize: 10.5,
-                      fontWeight: 700,
-                      display: "flex",
-                      alignItems: "center",
-                      justifyContent: "center",
-                    }}
-                  >
-                    {item.count}
-                  </div>
-                ) : null}
               </Link>
             );
           })}
@@ -273,10 +244,12 @@ const SideNav = () => {
           }}
         >
           <div style={{ width: 44, height: 44, borderRadius: "50%", overflow: "hidden", flexShrink: 0 }}>
-            <img
+            <Image
               src={currentUser.avatarUrl}
               alt={currentUser.name}
-              style={{ width: "100%", height: "100%", objectFit: "cover", display: "block" }}
+              width={44}
+              height={44}
+              style={{ objectFit: "cover", display: "block" }}
             />
           </div>
           <div style={{ flex: 1, minWidth: 0 }}>


### PR DESCRIPTION
## 概要

SideNav の件数バッジ表示を廃止し、ESLint エラー6件・警告3件を合わせて修正しました。

## 関連Issue

Closes #170
Closes #118

## 変更点

- **SideNav.tsx**（Issue #170）
  - `notificationRepository` / `subscriptionRepository` のインポートおよびバッジ件数計算ロジックを削除
  - `NavItem` 型から `count?: number` フィールドを削除
  - Collection・Notification ボタンへの `count` プロパティの設定を削除
  - バッジ（数値ピル）のレンダリング JSX を削除
  - 未使用となった `FaceBadge` インポートを削除
  - `<img>` を `next/image` の `<Image>` コンポーネントに置換

- **ESLint エラー修正**（6件）
  - `FacesClient.tsx`: 未使用変数 `totalSeeds` と グリッドビュー内の `kanji` を削除
  - `NotificationList.tsx`: 未使用 `getFaceColor` インポートを削除、未使用引数 `activityId` を削除
  - `ContextRail.tsx`: 未使用 `SeedRow` インポートを削除

- **ESLint 警告修正**（3件）
  - `HomeProfile.tsx` / `AppHeader.tsx` / `SideNav.tsx`: `<img>` を `<Image>` に置換（`next.config.ts` の remotePatterns 設定済み）

## 動作確認

- [ ] SideNav の Collection・Notification ボタンに件数バッジが表示されないこと
- [ ] ESLint がエラー0件で通ること（`npx eslint src --ext .ts,.tsx`）
- [ ] アバター画像（SideNav・AppHeader・HomeProfile）が正常に表示されること
